### PR TITLE
Opentofu linux vm

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,97 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "deploy/docker/**"
+      - "src/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "config/dagster/**"
+      - ".github/workflows/docker-build.yaml"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "deploy/docker/**"
+      - "src/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "config/dagster/**"
+      - ".github/workflows/docker-build.yaml"
+  workflow_dispatch:
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Dev images — build only (no push). Verify the dev Dockerfiles are valid.
+  # ---------------------------------------------------------------------------
+  build-dev:
+    name: Build dev image (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dagster-dev
+            dockerfile: deploy/docker/dagster.dev.Dockerfile
+          - name: pluginlake-dev
+            dockerfile: deploy/docker/pluginlake.dev.Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to dhi.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_REGISTRY_USERNAME }}
+          password: ${{ secrets.DHI_REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+  # ---------------------------------------------------------------------------
+  # Production images — build only, no push.
+  # ---------------------------------------------------------------------------
+  build-prod:
+    name: Build prod image (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dagster
+            dockerfile: deploy/docker/dagster-webserver.Dockerfile
+          - name: pluginlake
+            dockerfile: deploy/docker/pluginlake.Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to dhi.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_REGISTRY_USERNAME }}
+          password: ${{ secrets.DHI_REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/deploy/infra/cloud-init.yaml
+++ b/deploy/infra/cloud-init.yaml
@@ -1,0 +1,27 @@
+#cloud-config
+# First-boot provisioning for the pluginlake VM.
+# Installs and configures fail2ban to block brute-force SSH login attempts.
+
+package_update: true
+
+packages:
+  - fail2ban
+
+write_files:
+  - path: /etc/fail2ban/jail.d/sshd.conf
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [sshd]
+      enabled  = true
+      port     = ssh
+      filter   = sshd
+      maxretry = 1
+      findtime = 10m
+      bantime  = 1h
+      logpath  = %(sshd_log)s
+      backend  = %(sshd_backend)s
+
+runcmd:
+  - systemctl enable fail2ban
+  - systemctl restart fail2ban

--- a/deploy/infra/outputs.tf
+++ b/deploy/infra/outputs.tf
@@ -36,3 +36,25 @@ output "storage_primary_blob_endpoint" {
   description = "Primary blob endpoint URL."
   value       = azurerm_storage_account.main.primary_blob_endpoint
 }
+
+# -- Linux VM --
+
+output "vm_public_ip" {
+  description = "Public IP address of the Linux VM."
+  value       = var.vm_enabled ? azurerm_public_ip.main[0].ip_address : null
+}
+
+output "vm_private_ip" {
+  description = "Private IP address of the Linux VM."
+  value       = var.vm_enabled ? azurerm_network_interface.main[0].private_ip_address : null
+}
+
+output "vm_id" {
+  description = "Resource ID of the Linux VM."
+  value       = var.vm_enabled ? azurerm_linux_virtual_machine.main[0].id : null
+}
+
+output "vm_ssh_command" {
+  description = "SSH command to connect to the VM."
+  value       = var.vm_enabled ? "ssh ${var.vm_admin_username}@${azurerm_public_ip.main[0].ip_address}" : null
+}

--- a/deploy/infra/outputs.tf
+++ b/deploy/infra/outputs.tf
@@ -58,3 +58,13 @@ output "vm_ssh_command" {
   description = "SSH command to connect to the VM."
   value       = var.vm_enabled ? "ssh ${var.vm_admin_username}@${azurerm_public_ip.main[0].ip_address}" : null
 }
+
+output "vm_identity_client_id" {
+  description = "Client ID of the VM managed identity (use with `az acr login --identity` or Docker credential helpers)."
+  value       = var.vm_enabled ? azurerm_user_assigned_identity.vm[0].client_id : null
+}
+
+output "vm_identity_principal_id" {
+  description = "Principal ID of the VM managed identity."
+  value       = var.vm_enabled ? azurerm_user_assigned_identity.vm[0].principal_id : null
+}

--- a/deploy/infra/providers.tf
+++ b/deploy/infra/providers.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
   #   set ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID, ARM_SUBSCRIPTION_ID
 
   # Required in azurerm ~> 4.0; can also be set via ARM_SUBSCRIPTION_ID env var.
-  resource_provider_registrations = "register"
+  resource_provider_registrations = "core"
   subscription_id = var.subscription_id
 
   # Use Azure AD for storage data plane ops (required when shared_access_key_enabled = false).

--- a/deploy/infra/terraform.tfvars.example
+++ b/deploy/infra/terraform.tfvars.example
@@ -32,3 +32,19 @@ tags = {
   environment = "demo"
   managed_by  = "opentofu"
 }
+
+# Linux VM — disabled by default; set vm_enabled = true to provision.
+# vm_enabled       = true
+# vm_name          = "vm-plugin-demo-d"
+# vm_size          = "Standard_B2s"
+# vm_admin_username = "azureuser"
+# vm_ssh_public_key = "ssh-rsa AAAA..."  # paste your ~/.ssh/id_rsa.pub content
+# vm_ssh_source_address_prefix = "203.0.113.0/24"  # restrict SSH to your IP range
+# vm_os_disk_type   = "Standard_LRS"
+# vm_os_disk_size_gb = 30
+# vm_image = {
+#   publisher = "Canonical"
+#   offer     = "ubuntu-24_04-lts"
+#   sku       = "server"
+#   version   = "latest"
+# }

--- a/deploy/infra/variables.tf
+++ b/deploy/infra/variables.tf
@@ -84,3 +84,100 @@ variable "tags" {
     managed_by  = "opentofu"
   }
 }
+
+# ---------------------------------------------------------------------------
+# Linux VM
+# ---------------------------------------------------------------------------
+
+variable "vm_enabled" {
+  description = "Whether to create the Linux VM and its networking resources."
+  type        = bool
+  default     = false
+}
+
+variable "vm_name" {
+  description = "Name of the Linux virtual machine."
+  type        = string
+  default     = "vm-plugin-demo-d"
+}
+
+variable "vm_size" {
+  description = "Azure VM size (SKU)."
+  type        = string
+  default     = "Standard_B2s"
+}
+
+variable "vm_admin_username" {
+  description = "Admin username for the VM. Password auth is disabled; use SSH keys."
+  type        = string
+  default     = "azureuser"
+}
+
+variable "vm_ssh_public_key" {
+  description = "SSH public key for VM access. Required when vm_enabled = true."
+  type        = string
+  default     = ""
+}
+
+variable "vm_ssh_source_address_prefix" {
+  description = "CIDR or IP allowed to SSH into the VM. Use a restrictive value in production."
+  type        = string
+  default     = "*"
+}
+
+variable "vm_os_disk_type" {
+  description = "Managed disk type for the OS disk."
+  type        = string
+  default     = "Standard_LRS"
+
+  validation {
+    condition     = contains(["Standard_LRS", "StandardSSD_LRS", "Premium_LRS"], var.vm_os_disk_type)
+    error_message = "OS disk type must be Standard_LRS, StandardSSD_LRS, or Premium_LRS."
+  }
+}
+
+variable "vm_os_disk_size_gb" {
+  description = "Size of the OS disk in GB."
+  type        = number
+  default     = 30
+}
+
+variable "vm_image" {
+  description = "Source image reference for the VM."
+  type = object({
+    publisher = string
+    offer     = string
+    sku       = string
+    version   = string
+  })
+  default = {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+}
+
+variable "vm_vnet_name" {
+  description = "Name of the virtual network for the VM."
+  type        = string
+  default     = "vnet-plugin-demo-d"
+}
+
+variable "vm_vnet_address_space" {
+  description = "Address space for the virtual network."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vm_subnet_name" {
+  description = "Name of the subnet for the VM."
+  type        = string
+  default     = "snet-default"
+}
+
+variable "vm_subnet_address_prefix" {
+  description = "Address prefix for the VM subnet."
+  type        = string
+  default     = "10.0.1.0/24"
+}

--- a/deploy/infra/variables.tf
+++ b/deploy/infra/variables.tf
@@ -120,9 +120,14 @@ variable "vm_ssh_public_key" {
 }
 
 variable "vm_ssh_source_address_prefix" {
-  description = "CIDR or IP allowed to SSH into the VM. Use a restrictive value in production."
+  description = "CIDR or IP allowed to SSH into the VM. Must be a specific IP or CIDR (e.g. \"203.0.113.0/24\"). Using \"*\" exposes SSH to the entire internet."
   type        = string
   default     = "*"
+
+  validation {
+    condition     = var.vm_ssh_source_address_prefix != ""
+    error_message = "vm_ssh_source_address_prefix must not be empty. Use a CIDR like \"203.0.113.0/24\" or \"*\" for unrestricted (not recommended)."
+  }
 }
 
 variable "vm_os_disk_type" {
@@ -154,7 +159,9 @@ variable "vm_image" {
     publisher = "Canonical"
     offer     = "ubuntu-24_04-lts"
     sku       = "server"
-    version   = "latest"
+    # Pin to a specific version for reproducible deployments.
+    # Find available versions: az vm image list --publisher Canonical --offer ubuntu-24_04-lts --sku server --all -o table
+    version   = "24.04.202502210"
   }
 }
 

--- a/deploy/infra/vm.tf
+++ b/deploy/infra/vm.tf
@@ -74,6 +74,23 @@ resource "azurerm_network_interface" "main" {
   tags = var.tags
 }
 
+# User-assigned managed identity — grants the VM pull-only access to the Container Registry.
+resource "azurerm_user_assigned_identity" "vm" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = "${var.vm_name}-identity"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_role_assignment" "vm_acr_pull" {
+  count                = var.vm_enabled ? 1 : 0
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.vm[0].principal_id
+}
+
 resource "azurerm_linux_virtual_machine" "main" {
   count               = var.vm_enabled ? 1 : 0
   name                = var.vm_name
@@ -83,6 +100,7 @@ resource "azurerm_linux_virtual_machine" "main" {
 
   admin_username                  = var.vm_admin_username
   disable_password_authentication = true
+  custom_data                     = filebase64("${path.module}/cloud-init.yaml")
 
   lifecycle {
     precondition {
@@ -92,6 +110,11 @@ resource "azurerm_linux_virtual_machine" "main" {
   }
 
   network_interface_ids = [azurerm_network_interface.main[0].id]
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.vm[0].id]
+  }
 
   admin_ssh_key {
     username   = var.vm_admin_username

--- a/deploy/infra/vm.tf
+++ b/deploy/infra/vm.tf
@@ -1,0 +1,109 @@
+# ---------------------------------------------------------------------------
+# Azure Linux Virtual Machine — SSH-only access, no public password auth
+# ---------------------------------------------------------------------------
+
+resource "azurerm_virtual_network" "main" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = var.vm_vnet_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+  address_space       = [var.vm_vnet_address_space]
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet" "main" {
+  count                = var.vm_enabled ? 1 : 0
+  name                 = var.vm_subnet_name
+  resource_group_name  = data.azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main[0].name
+  address_prefixes     = [var.vm_subnet_address_prefix]
+}
+
+resource "azurerm_network_security_group" "main" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = "${var.vm_name}-nsg"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+
+  security_rule {
+    name                       = "AllowSSH"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = var.vm_ssh_source_address_prefix
+    destination_address_prefix = "*"
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "main" {
+  count                     = var.vm_enabled ? 1 : 0
+  subnet_id                 = azurerm_subnet.main[0].id
+  network_security_group_id = azurerm_network_security_group.main[0].id
+}
+
+resource "azurerm_public_ip" "main" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = "${var.vm_name}-pip"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = var.tags
+}
+
+resource "azurerm_network_interface" "main" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = "${var.vm_name}-nic"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.main[0].id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.main[0].id
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_linux_virtual_machine" "main" {
+  count               = var.vm_enabled ? 1 : 0
+  name                = var.vm_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+  size                = var.vm_size
+
+  admin_username                  = var.vm_admin_username
+  disable_password_authentication = true
+
+  network_interface_ids = [azurerm_network_interface.main[0].id]
+
+  admin_ssh_key {
+    username   = var.vm_admin_username
+    public_key = var.vm_ssh_public_key
+  }
+
+  os_disk {
+    name                 = "${var.vm_name}-osdisk"
+    caching              = "ReadWrite"
+    storage_account_type = var.vm_os_disk_type
+    disk_size_gb         = var.vm_os_disk_size_gb
+  }
+
+  source_image_reference {
+    publisher = var.vm_image.publisher
+    offer     = var.vm_image.offer
+    sku       = var.vm_image.sku
+    version   = var.vm_image.version
+  }
+
+  tags = var.tags
+}

--- a/deploy/infra/vm.tf
+++ b/deploy/infra/vm.tf
@@ -84,6 +84,13 @@ resource "azurerm_linux_virtual_machine" "main" {
   admin_username                  = var.vm_admin_username
   disable_password_authentication = true
 
+  lifecycle {
+    precondition {
+      condition     = var.vm_ssh_public_key != ""
+      error_message = "vm_ssh_public_key must be set when vm_enabled = true."
+    }
+  }
+
   network_interface_ids = [azurerm_network_interface.main[0].id]
 
   admin_ssh_key {

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -151,11 +151,32 @@ Runs on every push and pull request to `main` and `dev`:
 
 #### Docker Build Workflow (`docker-build.yaml`)
 
-Automatically builds and pushes Docker images to Azure Container Registry when relevant files change:
-- Triggers on push to `main` or `dev` when `src/`, `deploy/docker/`, `pyproject.toml`, or `uv.lock` change
-- Uses path filtering to only rebuild affected images
-- Tags: `latest` (main), `dev` (dev branch), and commit SHA
-- Includes SLSA provenance and SBOM attestations
+Automatically builds and validates Docker images on every push and pull request to `main` or `dev`. Images are never pushed — the workflow only verifies that all Dockerfiles build successfully.
+
+Triggers on changes to `deploy/docker/**`, `src/**`, `pyproject.toml`, `uv.lock`, `config/dagster/**`.
+
+**Dev images:**
+
+| Image | Dockerfile |
+|-------|-----------|
+| `dagster-dev` | `deploy/docker/dagster.dev.Dockerfile` |
+| `pluginlake-dev` | `deploy/docker/pluginlake.dev.Dockerfile` |
+
+**Production images:**
+
+| Image | Dockerfile |
+|-------|-----------|
+| `dagster` | `deploy/docker/dagster-webserver.Dockerfile` |
+| `pluginlake` | `deploy/docker/pluginlake.Dockerfile` |
+
+All four images are built in parallel. Docker layer caching is shared across runs using the GitHub Actions cache, keyed per image name.
+
+**Required GitHub Actions secrets:**
+
+| Secret | Description |
+|--------|-------------|
+| `DHI_REGISTRY_USERNAME` | Username for pulling base images from `dhi.io` |
+| `DHI_REGISTRY_PASSWORD` | Password for `dhi.io` |
 
 #### Dependabot
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,6 +6,7 @@ Step-by-step instructions for installing, deploying, and integrating pluginlake.
 |-------|-------------|
 | [Getting Started](getting-started.md) | Install pluginlake, launch the data pipeline, and run your first assets. |
 | [Docker](docker.md) | Container architecture, multi-stage builds, and secrets management. |
+| [Infrastructure](infrastructure.md) | Provision Azure resources (Container Registry, Storage, Linux VM) with OpenTofu. |
 | [Using as Package](using-as-package.md) | Add pluginlake as a dependency in your own data station project. |
 | [API](api.md) | REST API endpoints, middleware, authentication, and configuration. |
 | [API Specification](api-specification.md) | Interactive OpenAPI specification (Swagger UI). |

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -167,7 +167,7 @@ Enable it by setting `vm_enabled = true` in your `terraform.tfvars`.
 | `vm_ssh_source_address_prefix` | CIDR allowed to SSH in | `*` |
 | `vm_os_disk_type` | OS disk type | `Standard_LRS` |
 | `vm_os_disk_size_gb` | OS disk size in GB | `30` |
-| `vm_image` | Source image (publisher/offer/sku/version) | Ubuntu 24.04 LTS |
+| `vm_image` | Source image (publisher/offer/sku/version) | Ubuntu 24.04 LTS `24.04.202502210` |
 | `vm_vnet_name` | Virtual network name | `vnet-plugin-demo-d` |
 | `vm_vnet_address_space` | VNet address space | `10.0.0.0/16` |
 | `vm_subnet_name` | Subnet name | `snet-default` |
@@ -179,6 +179,24 @@ Enable it by setting `vm_enabled = true` in your `terraform.tfvars`.
 vm_enabled                   = true
 vm_ssh_public_key            = "ssh-rsa AAAA..."  # content of ~/.ssh/id_rsa.pub
 vm_ssh_source_address_prefix = "203.0.113.10/32"  # restrict to your IP
+```
+
+To use a different Ubuntu image version, override `vm_image` in your `terraform.tfvars`.
+List available versions first:
+
+```bash
+az vm image list --publisher Canonical --offer ubuntu-24_04-lts --sku server --all -o table
+```
+
+Then set the desired version:
+
+```hcl
+vm_image = {
+  publisher = "Canonical"
+  offer     = "ubuntu-24_04-lts"
+  sku       = "server"
+  version   = "24.04.202502210"
+}
 ```
 
 !!! tip

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -1,0 +1,249 @@
+# Infrastructure
+
+This guide covers how to provision Azure resources for pluginlake using OpenTofu (or Terraform).
+All configuration lives in `deploy/infra/`.
+
+## Prerequisites
+
+- [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.6.0 (or Terraform >= 1.6.0)
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`)
+- An existing Azure resource group
+
+Authenticate with Azure CLI before running any commands:
+
+```bash
+az login
+az account set --subscription "<your-subscription-id>"
+```
+
+## File layout
+
+```
+deploy/infra/
+├── main.tf            # Locals and data sources (resource group reference)
+├── providers.tf       # Provider and version constraints
+├── variables.tf       # All input variables with defaults
+├── outputs.tf         # Output values after apply
+├── acr.tf             # Azure Container Registry + RBAC
+├── storage.tf         # Azure Storage Account + blob containers + RBAC
+├── vm.tf              # Linux VM + networking (opt-in)
+├── terraform.tfvars.example  # Template for your variable values
+└── terraform.tfvars   # Your actual values (git-ignored)
+```
+
+## Getting started
+
+### 1. Initialize the working directory
+
+```bash
+cd deploy/infra
+tofu init
+```
+
+This downloads the `azurerm` provider and sets up the backend.
+
+### 2. Create your variable file
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` and fill in your subscription ID at minimum:
+
+```hcl
+subscription_id = "your-subscription-id-here"
+```
+
+!!! warning
+    Never commit `terraform.tfvars` to version control. It contains sensitive values.
+
+### 3. Preview changes
+
+```bash
+tofu plan
+```
+
+Review the output to see what resources will be created.
+
+### 4. Apply
+
+```bash
+tofu apply
+```
+
+Confirm with `yes` when prompted.
+
+## Resources
+
+### Container Registry
+
+Defined in `acr.tf`. Always created.
+
+Provides a private Azure Container Registry with admin access disabled and anonymous pulls blocked.
+All access is through Azure AD / service principal RBAC.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `acr_name` | Registry name (hyphens stripped automatically) | `cr-plugin-demo-d` |
+| `acr_sku` | SKU tier (`Basic`, `Standard`, `Premium`) | `Basic` |
+| `acr_pull_principal_object_id` | Object ID for pull-only (AcrPull) access | `""` (skip) |
+| `acr_push_principal_object_id` | Object ID for push+pull (AcrPush) access | `""` (skip) |
+
+**Example: grant CI/CD push access and deployment pull access**
+
+```hcl
+acr_push_principal_object_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # CI pipeline SP
+acr_pull_principal_object_id = "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj"  # deployment runner SP
+```
+
+Find a principal's Object ID:
+
+```bash
+az ad sp show --id <APP_ID> --query id -o tsv
+```
+
+**Outputs:**
+
+| Output | Description |
+|--------|-------------|
+| `acr_name` | Name of the registry |
+| `acr_login_server` | Login server URL (use with `docker login`) |
+| `acr_id` | Resource ID |
+
+After apply, push images with:
+
+```bash
+az acr login --name $(tofu output -raw acr_name)
+docker tag pluginlake $(tofu output -raw acr_login_server)/pluginlake:latest
+docker push $(tofu output -raw acr_login_server)/pluginlake:latest
+```
+
+### Storage Account
+
+Defined in `storage.tf`. Always created.
+
+Provides a private Azure Blob Storage account with shared key access disabled, forcing Azure AD authentication only.
+Includes soft delete (7 days) and enforces TLS 1.2+.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `storage_account_name` | Account name (hyphens stripped automatically) | `st-plugin-demo-d` |
+| `storage_account_tier` | Performance tier | `Standard` |
+| `storage_replication_type` | Replication (`LRS`, `GRS`, etc.) | `LRS` |
+| `storage_containers` | Blob containers to pre-create | `[]` |
+| `service_principal_object_id` | Object ID for Storage Blob Data Contributor access | `""` (skip) |
+
+**Example: create containers and grant SP access**
+
+```hcl
+storage_containers          = ["raw", "processed", "output"]
+service_principal_object_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+```
+
+**Outputs:**
+
+| Output | Description |
+|--------|-------------|
+| `storage_account_name` | Name of the storage account |
+| `storage_account_id` | Resource ID |
+| `storage_primary_blob_endpoint` | Primary blob endpoint URL |
+
+### Linux VM
+
+Defined in `vm.tf`. Opt-in, disabled by default.
+
+Provisions an Ubuntu 24.04 LTS virtual machine with SSH key authentication only (password auth disabled).
+Includes a virtual network, subnet, network security group (SSH-only inbound), public IP, and network interface.
+
+Enable it by setting `vm_enabled = true` in your `terraform.tfvars`.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `vm_enabled` | Feature flag to create VM resources | `false` |
+| `vm_name` | VM name | `vm-plugin-demo-d` |
+| `vm_size` | Azure VM size | `Standard_B2s` |
+| `vm_admin_username` | SSH admin username | `azureuser` |
+| `vm_ssh_public_key` | SSH public key (required when enabled) | `""` |
+| `vm_ssh_source_address_prefix` | CIDR allowed to SSH in | `*` |
+| `vm_os_disk_type` | OS disk type | `Standard_LRS` |
+| `vm_os_disk_size_gb` | OS disk size in GB | `30` |
+| `vm_image` | Source image (publisher/offer/sku/version) | Ubuntu 24.04 LTS |
+| `vm_vnet_name` | Virtual network name | `vnet-plugin-demo-d` |
+| `vm_vnet_address_space` | VNet address space | `10.0.0.0/16` |
+| `vm_subnet_name` | Subnet name | `snet-default` |
+| `vm_subnet_address_prefix` | Subnet address prefix | `10.0.1.0/24` |
+
+**Example: enable the VM**
+
+```hcl
+vm_enabled                   = true
+vm_ssh_public_key            = "ssh-rsa AAAA..."  # content of ~/.ssh/id_rsa.pub
+vm_ssh_source_address_prefix = "203.0.113.10/32"  # restrict to your IP
+```
+
+!!! tip
+    Always set `vm_ssh_source_address_prefix` to your IP or office CIDR in production instead of the default `*`.
+
+**Outputs:**
+
+| Output | Description |
+|--------|-------------|
+| `vm_public_ip` | Public IP address |
+| `vm_private_ip` | Private IP address |
+| `vm_id` | Resource ID |
+| `vm_ssh_command` | Ready-to-use SSH command |
+
+After apply, connect to the VM:
+
+```bash
+tofu output -raw vm_ssh_command
+# ssh azureuser@<public-ip>
+```
+
+## Common variables
+
+These variables apply to all resources:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `subscription_id` | Azure subscription ID (sensitive) | — |
+| `resource_group_name` | Existing resource group name | `rg-plugin-demo-d` |
+| `location` | Azure region | `westeurope` |
+| `tags` | Tags applied to all resources | `project=pluginlake, environment=demo, managed_by=opentofu` |
+
+## Common operations
+
+### View current outputs
+
+```bash
+tofu output
+```
+
+### Destroy all resources
+
+```bash
+tofu destroy
+```
+
+### Destroy a specific resource
+
+```bash
+tofu destroy -target=azurerm_linux_virtual_machine.main
+```
+
+### Import an existing resource
+
+```bash
+tofu import azurerm_storage_account.main /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<name>
+```
+
+### CI/CD authentication
+
+For non-interactive environments, authenticate via service principal environment variables instead of `az login`:
+
+```bash
+export ARM_CLIENT_ID="..."
+export ARM_CLIENT_SECRET="..."
+export ARM_TENANT_ID="..."
+export ARM_SUBSCRIPTION_ID="..."
+```

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -210,6 +210,8 @@ vm_image = {
 | `vm_private_ip` | Private IP address |
 | `vm_id` | Resource ID |
 | `vm_ssh_command` | Ready-to-use SSH command |
+| `vm_identity_client_id` | Client ID of the VM managed identity |
+| `vm_identity_principal_id` | Principal ID of the VM managed identity |
 
 After apply, connect to the VM:
 
@@ -217,6 +219,45 @@ After apply, connect to the VM:
 tofu output -raw vm_ssh_command
 # ssh azureuser@<public-ip>
 ```
+
+### fail2ban
+
+fail2ban is configured automatically on first boot via cloud-init (`deploy/infra/cloud-init.yaml`).
+It installs the `fail2ban` package and sets up SSH jail protection:
+
+| Setting | Value |
+|---------|-------|
+| Max failed attempts | 5 |
+| Detection window | 10 minutes |
+| Ban duration | 1 hour |
+
+To check the status after SSH-ing into the VM:
+
+```bash
+sudo systemctl status fail2ban
+sudo fail2ban-client status sshd
+```
+
+### ACR pull access
+
+The VM is assigned a user-assigned managed identity (`${vm_name}-identity`) with the `AcrPull` role on the Container Registry.
+This allows the VM to pull images from ACR without storing credentials.
+
+To authenticate Docker on the VM using the managed identity:
+
+```bash
+# Install Azure CLI on the VM, then:
+az login --identity
+az acr login --name $(az acr list --query "[0].name" -o tsv)
+```
+
+Or using the `acr` credential helper:
+
+```bash
+docker pull <acr-login-server>/pluginlake:latest
+```
+
+The managed identity client ID is available via `tofu output -raw vm_identity_client_id`.
 
 ## Common variables
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -12,6 +12,7 @@ nav = [
         { "Guides" = "guides/index.md" },
         { "Getting Started" = "guides/getting-started.md" },
         { "Docker" = "guides/docker.md" },
+        { "Infrastructure" = "guides/infrastructure.md" },
         { "Using as Package" = "guides/using-as-package.md" },
         { "API" = "guides/api.md" },
         { "API Specification" = "guides/api-specification.md" },


### PR DESCRIPTION
This pull request introduces significant improvements to the infrastructure and CI/CD pipeline by adding support for provisioning a Linux VM in Azure using OpenTofu, enhancing security with automated configuration, and updating the Docker build workflow. The changes include new Terraform resources and variables for VM deployment, a cloud-init script for first-boot security hardening, and documentation updates to reflect the new capabilities.

**Infrastructure: Azure Linux VM provisioning**

* Added Terraform resources in `vm.tf` to provision a Linux VM (with SSH-only access), networking (VNet, subnet, NSG with SSH restriction), public/private IPs, and a managed identity for secure ACR access. All resources are conditionally created based on the `vm_enabled` variable.
* Introduced new variables in `variables.tf` for VM configuration (name, size, admin username, SSH key, networking, disk, image, etc.), with validation and sensible defaults.
* Added example configuration for the Linux VM in `terraform.tfvars.example`, showing how to enable and customize the VM deployment.
* Exposed new output variables in `outputs.tf` for VM public/private IP, resource ID, SSH command, and managed identity info.

**Security and provisioning**

* Added a `cloud-init.yaml` script to automatically install and configure `fail2ban` on first boot, protecting the VM from SSH brute-force attacks.

**CI/CD pipeline improvements**

* Replaced the Docker build workflow in `.github/workflows/docker-build.yaml` to build and validate all dev and production Docker images on every push and pull request (no longer pushes images), with improved cache usage and matrix builds.
* Updated development documentation to reflect the new Docker workflow, image build matrix, and required secrets.

**Documentation**

* Added an "Infrastructure" guide to the docs index, describing how to provision Azure resources with OpenTofu.

**Other**

* Changed the Azure provider configuration to use `resource_provider_registrations = "core"` for better compatibility.