### PR TITLE
fixed uv dependencies

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,7 @@ jobs:
         run: uv python install
 
       - name: Install dependencies
-        run: uv sync --group docs
+        run: uv sync --group docs --extra fhir
 
       - name: Export OpenAPI schema
         run: uv run python scripts/export_openapi.py


### PR DESCRIPTION
This pull request makes a minor update to the documentation workflow by ensuring that the FHIR extra dependencies are installed when syncing the docs environment.

* In `.github/workflows/docs.yaml`, updated the dependencies installation step to include the `fhir` extra when running `uv sync` for the docs group.