### PR TITLE
AuthC/AuthZ uitzoeken NUTS + dataspace spec + dev guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,64 +1,7 @@
 # Copilot Instructions for pluginlake
 
-## Python
-
-- Target Python 3.13+. Do not use `from __future__ import annotations`.
-- Use native type hints (`str | None`, `list[int]`, etc.) instead of `typing` equivalents.
-- Write small, focused functions. Only use nested functions or inline imports when they provide a clear benefit.
-- Keep classes stateless. Use classes to group related functionality, not to hold mutable state.
-- Prefer returning values over mutating arguments.
-- Use `logging` via `get_logger(__name__)` from `pluginlake.utils.logger`, never `print()`.
-- Use Google-style docstrings.
-- always scan pyproject.toml for preferred code style and linting settings.
-
-## Project tooling
-
-- Always use `uv` as the package manager and task runner.
-- All settings and tool configuration live in `pyproject.toml`.
-- Run commands with `uv run` (e.g., `uv run pytest`, `uv run ruff check .`).
-- Use `just` recipes for common tasks.
-
-## Configuration
-
-- Use Pydantic Settings (`pydantic-settings`) for all configuration.
-- Root settings are in `pluginlake/config.py`.
-- Each submodule can have its own `config.py` with a `Settings` child class.
-- Keep config in config files, not scattered through business logic.
-
-## Code organization
-
-- `pluginlake/utils/` contains generic, reusable functions and helpers used across the project.
-- Do not put reusable code inside submodules if it will be shared elsewhere.
-- Each submodule should be self-contained with clear boundaries.
-- Assets and definitions go in `src/pluginlake/assets/` and `src/pluginlake/definitions/`, not in core or utils.
-- Don't use `__init__.py` files for logic. They should only contain imports and module-level docstrings.
-
-## Testing
-
-- Use `pytest` for all tests.
-- Write tests as plain functions, not inside classes. Use fixtures for shared setup.
-- Only test our own code, not functionality from external packages/libraries.
-- Test files mirror the source structure under `tests/unit/pluginlake/`.
-- Keep tests simple and focused on one behavior per test.
-
-## Data
-
-- Use Polars for DataFrame operations, not pandas.
-- Prefer lazy evaluation where possible.
-- Only reuse data assets between pipelines if they are the exact same dataset.
-
-## Markdown
-
-- Do not hard-wrap lines to a fixed column width. Write each sentence or logical phrase as a single line.
-- Use em dashes sparingly; prefer commas, colons, or parentheses.
-- Don't overuse bold, italics or emojis. Use them only for emphasis when necessary.
-- check for mkdocs or zensical configs in zensical.toml, pyproject.tom or mkdocs.yaml before suggesting markdown formatting or structure.
-
-## Brand & styling
-
-- Brand colors, typography, spacing and component styles are defined in `.github/skills/plugin-brand.md`.
-- Always reference that file when generating or modifying UI, documentation themes, or Streamlit custom CSS.
-- Logo and brand assets live in `assets/` at the project root.
+All coding conventions and project rules are defined in [AGENTS.md](../AGENTS.md) at the repository root.
+This file extends those instructions with GitHub Copilot-specific configuration.
 
 ## GitHub issues & project boards
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot version updates.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # GitHub Actions workflow versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/deploy/docker"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/docker-build.yaml.disabled
+++ b/.github/workflows/docker-build.yaml.disabled
@@ -1,0 +1,75 @@
+# DISABLED SCAFFOLD — not active.
+#
+# This workflow is intentionally kept with a `.disabled` extension so GitHub
+# does NOT run it. It is a starting point for building and pushing the four
+# production images to ACR.
+#
+# Before enabling (rename to `docker-build.yaml`):
+#   1. Decide auth. OIDC federated login is recommended for a public repo
+#      (add `azure/login`, `permissions: id-token: write`, no stored secret).
+#      The SP-secret variant below needs `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET`.
+#   2. Confirm the registry host and image namespace.
+#   3. Review the push trigger and path filters.
+
+name: Docker Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Extra tag to push (defaults to commit SHA)"
+        required: false
+        default: ""
+
+env:
+  AZURE_CONTAINER_REGISTRY: drplugindhdprd.azurecr.io
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.image }}
+    # Hard stop: this scaffold must never run until auth is configured.
+    if: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: docker-${{ github.ref }}-${{ matrix.image }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: pluginlake
+            dockerfile: deploy/docker/pluginlake.Dockerfile
+          - image: dagster-webserver
+            dockerfile: deploy/docker/dagster-webserver.Dockerfile
+          - image: ui-central
+            dockerfile: deploy/docker/ui-central.Dockerfile
+          - image: ui-datastation
+            dockerfile: deploy/docker/ui-datastation.Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.AZURE_CONTAINER_REGISTRY }}
+          username: ${{ secrets.AZURE_CLIENT_ID }}
+          password: ${{ secrets.AZURE_CLIENT_SECRET }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          provenance: true
+          sbom: true
+          tags: |
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/pluginlake/${{ matrix.image }}:latest
+            ${{ env.AZURE_CONTAINER_REGISTRY }}/pluginlake/${{ matrix.image }}:${{ github.sha }}
+            ${{ inputs.image_tag != '' && format('{0}/pluginlake/{1}:{2}', env.AZURE_CONTAINER_REGISTRY, matrix.image, inputs.image_tag) || '' }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: dev
+    branches: main
     paths:
       - "docs/**"
       - "src/pluginlake/api/**"
@@ -51,7 +51,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    if: github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# Agent Instructions for pluginlake
+
+This file provides instructions for AI coding agents working on this project.
+It is tool-agnostic and applies to any AI assistant (GitHub Copilot, Claude, Cursor, etc.).
+
+For tool-specific configuration, see `.github/copilot-instructions.md`.
+
+## Python
+
+- Target Python 3.13+. Do not use `from __future__ import annotations`.
+- Use native type hints (`str | None`, `list[int]`, etc.) instead of `typing` equivalents.
+- Write small, focused functions. Only use nested functions or inline imports when they provide a clear benefit.
+- Keep classes stateless. Use classes to group related functionality, not to hold mutable state.
+- Prefer returning values over mutating arguments.
+- Use `logging` via `get_logger(__name__)` from `pluginlake.utils.logger`, never `print()`.
+- Use Google-style docstrings.
+- Always scan `pyproject.toml` for preferred code style and linting settings.
+
+## Project tooling
+
+- Always use `uv` as the package manager and task runner.
+- All settings and tool configuration live in `pyproject.toml`.
+- Run commands with `uv run` (e.g., `uv run pytest`, `uv run ruff check .`).
+- Use `just` recipes for common tasks.
+
+## Configuration
+
+- Use Pydantic Settings (`pydantic-settings`) for all configuration.
+- Root settings are in `pluginlake/config.py`.
+- Each submodule can have its own `config.py` with a `Settings` child class.
+- Keep config in config files, not scattered through business logic.
+
+## Code organization
+
+- `pluginlake/utils/` contains generic, reusable functions and helpers used across the project.
+- Do not put reusable code inside submodules if it will be shared elsewhere.
+- Each submodule should be self-contained with clear boundaries.
+- Assets and definitions go in `src/pluginlake/assets/` and `src/pluginlake/definitions/`, not in core or utils.
+- Don't use `__init__.py` files for logic. They should only contain imports and module-level docstrings.
+
+## Testing
+
+- Use `pytest` for all tests.
+- Write tests as plain functions, not inside classes. Use fixtures for shared setup.
+- Only test our own code, not functionality from external packages/libraries.
+- Test files mirror the source structure under `tests/unit/pluginlake/`.
+- Keep tests simple and focused on one behavior per test.
+
+## Data
+
+- Use Polars for DataFrame operations, not pandas.
+- Prefer lazy evaluation where possible.
+- Only reuse data assets between pipelines if they are the exact same dataset.
+
+## Markdown
+
+- Do not hard-wrap lines to a fixed column width. Write each sentence or logical phrase as a single line.
+- Use em dashes sparingly; prefer commas, colons, or parentheses.
+- Don't overuse bold, italics or emojis. Use them only for emphasis when necessary.
+- Check for zensical configs in `zensical.toml` or `pyproject.toml` before suggesting markdown formatting or structure.
+
+## Brand and styling
+
+- Brand colors, typography, spacing and component styles are defined in `.github/skills/plugin-brand.md`.
+- Always reference that file when generating or modifying UI, documentation themes, or Streamlit custom CSS.
+- Logo and brand assets live in `assets/` at the project root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- ADR-007: Dataspace Protocol, authentication, and authorization architecture (EHDS/Health-RI compliant, VC-native ODRL).
+- `docs/background/` section for design research (not in public nav):
+  - `dsp-authorization.md`: DSP design specification with options analysis, UX workflows, RBAC entity model, and implementation reference.
+  - `federated-infrastructure.md`: federated infrastructure comparison (Nuts, vantage6, Flower, FLARE, EU dataspaces).
+
+### Changed
+
+- ADR-006 rewritten: scoped to Nuts as organizational identity layer only (node-to-node trust boundary). Added Processing Hub terminology, governance rules, trust boundary definitions, and credential role enforcement.
+- ADR-003: clarified rejected "landing zone" alternative with explicit rationale for direct FastAPI-to-Dagster triggering.
+- Docs nav restructured in `zensical.toml`: ADR-006 and ADR-007 added to Decisions section.
+
+## [0.1.1] — 2026-06-03
+
+### Security
+
+- Tornado bumped 6.5.4 → 6.5.5 (dependabot).
+
+## [0.1.0] — 2026-03-16
+
+### Highlights
+
+- DuckLake-backed data catalog with PostgreSQL catalog metadata.
+- Dagster orchestration with custom DuckLake I/O manager.
+- FHIR ingestion into OMOP CDM.
+- FastAPI data access layer.
+- Datastation dashboard (Streamlit).
+- Docker Compose setup for dev and prod.
+- Azure infrastructure (OpenTofu modules).
+- Documentation site via GitHub Pages.
+- CI/CD with GitHub Actions.
+- OMOP vocabulary support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ADR-006 rewritten: scoped to Nuts as organizational identity layer only (node-to-node trust boundary). Added Processing Hub terminology, governance rules, trust boundary definitions, and credential role enforcement.
 - ADR-003: clarified rejected "landing zone" alternative with explicit rationale for direct FastAPI-to-Dagster triggering.
 - Docs nav restructured in `zensical.toml`: ADR-006 and ADR-007 added to Decisions section.
+- License changed from MIT to Apache-2.0.
 
 ## [0.1.1] — 2026-06-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,4 @@ See the [release process](docs/development/develop-guidelines.md#release-process
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to pluginlake
+
+Thanks for your interest in contributing to pluginlake!
+This guide covers the essentials for getting started.
+For detailed technical standards (code style, testing, CI), see the [development guidelines](docs/development/develop-guidelines.md).
+
+## Prerequisites
+
+- Python 3.13+
+- [uv](https://docs.astral.sh/uv/) (package manager and task runner)
+- [just](https://github.com/casey/just) (command runner)
+- Docker and Docker Compose
+
+## Getting started
+
+```bash
+# Clone the repository
+git clone https://github.com/plugin-healthcare/pluginlake.git
+cd pluginlake
+
+# Install dependencies
+uv sync
+
+# Install pre-commit hooks
+pre-commit install
+
+# Run tests to verify setup
+uv run pytest
+
+# Run linting
+uv run ruff check .
+```
+
+## Branching
+
+We use GitHub Flow with a single long-lived branch:
+
+- `main` is always deployable (protected, requires PR review).
+- Create feature branches from `main`, named `<category>/<description>`:
+  - `feat/cli-module`
+  - `fix/port-mismatch`
+  - `docs/adrs-changelog`
+
+## Making changes
+
+1. Create a branch from `main`.
+2. Make your changes in small, focused commits.
+3. Run linting and tests before pushing:
+   ```bash
+   uv run ruff check .
+   uv run ty check .
+   uv run pytest
+   ```
+4. Open a pull request against `main`.
+
+## Pull request expectations
+
+- Describe what the PR does and why.
+- Keep PRs focused — one logical change per PR.
+- Ensure CI passes (linting, tests).
+- Update documentation if your change affects user-facing behavior.
+- Update `CHANGELOG.md` under `[Unreleased]` if the change is notable.
+
+## Commit messages
+
+Write clear commit messages. No strict format enforced, but prefer:
+
+- A concise subject line (imperative mood, e.g., "Add CLI init command")
+- A body explaining *why* if the change isn't obvious
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/).
+Documentation-only changes, CI updates, and test additions do not bump the version.
+See the [release process](docs/development/develop-guidelines.md#release-process) for details.
+
+## Reporting issues
+
+- Use GitHub Issues for bugs and feature requests.
+- Include steps to reproduce for bugs.
+- Check existing issues before creating a new one.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 PLUGIN consortium
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,0 +1,95 @@
+# Session Handoff
+
+This document tracks the current state of work across Copilot sessions.
+Each session must update this file before completing.
+
+## Current State
+
+**Branch:** `docker-deploy-cli`
+**Status:** In progress — ADR cross-consistency fixes complete, ready to commit docs changes
+**Last updated:** 2026-06-03
+
+## What Was Done
+
+### This session (2026-06-03, continued)
+
+- Added foundational glossary to ADR-007 (DID, VC, VP, signature, OIDC, Nuts, DSP, ODRL, contract, DPoP, Bolt, Permission) with "how they relate" paragraph explaining contract → VC → permission hierarchy.
+- Fixed cross-ADR inconsistencies:
+  - ADR-003: clarified rejected "landing zone" alternative (decoupled polling vs direct trigger).
+  - ADR-006: reconciled deployment contradiction (separate in production, colocation dev/test only).
+  - ADR-006: defined boundary-2 role mechanism (`role` claim in `NutsOrganizationCredential`, station policy validates `role: hub`).
+- Confirmed data flow pattern: write path always through Dagster; read/serve path is FastAPI → DuckLake directly.
+- Confirmed DuckDB/DuckLake/Quack stack stays; Quack not yet relevant (Dagster still needs Postgres).
+
+### This session (2026-06-03, earlier)
+
+- Restructured documentation into proper ADR + Background pattern:
+  - **ADR-007** slimmed from ~680 lines → 216 lines (context, decision, consequences, open questions only).
+  - **`docs/background/dsp-authorization.md`** created: design spec extracted from ADR-007 (routes, schemas, state machines, RBAC, enforcement, phased delivery).
+  - **`docs/background/federated-infrastructure.md`** created: final published version of platform comparison with balanced vantage6 framing.
+  - **`docs/background/index.md`** created: landing page for the Background section.
+- Added "Background" nav section to `zensical.toml`; added ADR-006/007 to Decisions nav.
+- Removed `docs/reference/federated-infrastructure.md` and `docs/reference/federated-infrastructure-v2.md` (consolidated).
+- ADR-007 clarity fixes: trust boundary definitions in terminology, EHDS/TEHDAS2 links, hub/station distinction, undefined terms explained (Bolt, TCK, StatusList2021, ODRL Level 2), two-auth-layer mechanism documented.
+- Vantage6 tone: reframed limitations as scale-dependent trade-offs, acknowledged current production use via pluginml.
+
+### Previous session (2026-06-02)
+
+- Split ADR-007 into two files for easier review and commit:
+  - `adr-007-dataspace-protocol-authz-authc-rbac.md` (685 lines, 30KB): concise decision record with all architecture, enforcement, phased delivery, and implementation-ready content.
+  - `adr-007-dataspace-protocol-authz-authc-rbac-reference.md` (1634 lines, 83KB): full reference with detailed options analysis, dashboard UX workflows, RBAC entity model, and international standards appendix.
+- Cross-linked both files in both directions.
+- Updated `docs/decisions/README.md` to include ADR-006 and ADR-007 entries.
+
+### Previous session (2026-05-28)
+
+- Thoroughly reviewed ADR-007 (dataspace protocol architecture) as senior architect.
+- Iteratively refined architecture through discussion: OPA → VC-native ODRL, station-authoritative model.
+- Major structural cleanup of ADR-007: removed 160 lines of OPA content, rewrote workflows/governance/RBAC sections for internal consistency.
+- Independent model review (rubber-duck agent): addressed 2 blocking + 5 non-blocking findings.
+- Added TL;DR, terminology table, ADR-008 forward references, v1 scope clarification.
+- **Split ADR-006 and ADR-007 into clean separation of concerns:**
+  - ADR-006 (366 lines): Nuts Node integration — organizational identity, sidecar deployment, middleware, DID model, federation topologies, SDC safety, Bolt definition, researcher identity scoping.
+  - ADR-007 (1632 lines): DSP + authorization — contract negotiation, per-user VCs with ODRL, enforcement, RBAC, governance models.
+  - Cross-references between both ADRs.
+- Clarified researcher identity model: "A researcher's identity is scoped to a processing hub. Each hub issues its own independent credentials and permits."
+
+### Previous session
+
+- Rebuilt Docker deployment architecture (separate webserver, daemon, code-server).
+- Created `pluginlake` CLI for deployment lifecycle management.
+- Passed code review (security + production readiness).
+
+## What Needs To Be Done
+
+### Immediate
+
+- [x] Final review of restructured docs (ADR-007, dsp-authorization.md, federated-infrastructure.md).
+- [x] Cross-ADR consistency review and fixes.
+- [ ] Fix ADR-004 cross-references (points to ADR-002 for staging/logs, should be ADR-003) — minor.
+- [ ] Commit docs restructure.
+- [ ] Commit and push `docker-deploy-cli` branch (40 files from previous session).
+- [ ] Open PR against `dev`.
+
+### Next priorities
+
+- [ ] Write ADR-008: contract-to-compute mapping, query safety, algorithm approval, privacy validation for non-aggregates.
+- [ ] Begin Phase 1 implementation planning (`src/pluginlake/dsp/`, `src/pluginlake/authz/`).
+- [ ] Test full production compose startup end-to-end.
+- [ ] Test CLI `pluginlake init` flow on a clean machine.
+
+## Known Issues
+
+- Dagster jobs may still OOM if host memory is limited and both ingest jobs run concurrently.
+- Type checking has some pre-existing issues unrelated to current branches.
+
+## Context for Next Session
+
+- **Docs structure:** ADRs in `docs/decisions/` (short decision records). Design specs and research in `docs/background/`. API reference in `docs/reference/` (auto-generated).
+- ADR-006 = "which orgs can connect" (Nuts, trust boundary 2). Now includes role claim mechanism (hub vs station).
+- ADR-007 = "what users/queries are allowed" (DSP + VC + ODRL, trust boundaries 1 & 3). Now includes foundational glossary. Points to `background/dsp-authorization.md` for implementation detail (private, not in nav).
+- `docs/background/federated-infrastructure.md` is the published platform comparison. Explicitly acknowledges pluginml uses vantage6 in production.
+- ADR-008 is needed for: structured filter AST, pre-approved algorithm registry, privacy validation for non-aggregates, station-side credential sync, techniques to limit destructive operations.
+- All work is on `docker-deploy-cli` branch, branched from `dev`.
+- Tests pass (`uv run pytest` — 250 tests).
+- Linting clean (`uv run ruff check .`).

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -69,7 +69,7 @@ Each session must update this file before completing.
 - [ ] Fix ADR-004 cross-references (points to ADR-002 for staging/logs, should be ADR-003) — minor.
 - [ ] Commit docs restructure.
 - [ ] Commit and push `docker-deploy-cli` branch (40 files from previous session).
-- [ ] Open PR against `dev`.
+- [ ] Open PR against `main`.
 
 ### Next priorities
 
@@ -90,6 +90,6 @@ Each session must update this file before completing.
 - ADR-008 = "what users/queries are allowed" (DSP + VC + ODRL, trust boundaries 1 & 3). Now includes foundational glossary. Points to `background/dsp-authorization.md` for implementation detail (private, not in nav).
 - `docs/background/federated-infrastructure.md` is the published platform comparison. Explicitly acknowledges pluginml uses vantage6 in production.
 - ADR-008 is needed for: structured filter AST, pre-approved algorithm registry, privacy validation for non-aggregates, station-side credential sync, techniques to limit destructive operations.
-- All work is on `docker-deploy-cli` branch, branched from `dev`.
+- All work is on `docker-deploy-cli` branch, branched from `main`.
 - Tests pass (`uv run pytest` — 250 tests).
 - Linting clean (`uv run ruff check .`).

--- a/docs/background/dsp-authorization.md
+++ b/docs/background/dsp-authorization.md
@@ -1,0 +1,1726 @@
+# DSP Authorization Architecture
+
+Design specification for how the Eclipse Dataspace Protocol, Nuts identity, and ODRL authorization map onto pluginlake's existing components (FastAPI, Dagster, DuckLake).
+
+This document is the implementation companion to [ADR-007](../decisions/adr-007-dataspace-protocol-authz-authc-rbac.md) (the decision record).
+
+---
+
+## How DSP/Nuts/ODRL map to pluginlake
+
+The table below shows which external standard concept maps to which pluginlake component, and what role each plays:
+
+| Standard concept | pluginlake component | Role |
+|---|---|---|
+| DSP Catalog Protocol | FastAPI `/dsp/catalog` + station asset registry (YAML) | Exposes which datasets a station offers, with what terms |
+| DSP Contract Negotiation | FastAPI routes + pluginlake database (`dsp.negotiation`) | Bilateral agreement between hub and station on what's allowed |
+| DSP Transfer Process | FastAPI routes + Dagster materialization + pluginlake database (`dsp.transfer_process`) | Triggers compute, tracks execution, issues scoped data access |
+| Nuts DID + NutsOrganizationCredential | Nuts Node sidecar + FastAPI middleware | Proves which organization is making a request (boundary 2) |
+| Nuts DPoP access token | `Authorization` header on every inter-node HTTP call | Per-request proof of org identity, validated by local Nuts Node |
+| PluginlakeAccessCredential (VC) | Hub issues → station verifies (PyJWT + cryptography) | Per-request proof of user permissions (boundary 3) |
+| ODRL policy (in agreement) | JSON in `dsp.negotiation.policy` column | Outer bounds: what the agreement allows |
+| ODRL permissions (in VC) | Embedded in PluginlakeAccessCredential | Inner bounds: what this specific user is allowed |
+| ODRL profile evaluation | `src/pluginlake/authz/` Python module (~300 lines) | Intersects agreement + VC + station-local restrictions |
+| Station asset registry | YAML config → maps ODRL URNs to DuckLake tables/Dagster assets | Station-local truth about what data exists and what's exposable |
+| Station operation registry | YAML config → maps ODRL actions to SQL templates/Dagster jobs | Station-local truth about what computations are allowed |
+| Privacy validation | Polars-based post-execution checks | k-anonymity, cardinality limits, applied after query execution |
+
+---
+
+## DSP Catalog ↔ Asset Registry + FastAPI
+
+**DSP says:** A provider exposes a DCAT catalog with datasets and their ODRL offers.
+
+**pluginlake does:** The station maintains a YAML asset registry that defines which DuckLake tables/Dagster assets are externally visible. The `/dsp/catalog` endpoint generates the DCAT response from this registry at request time.
+
+```
+DSP Catalog Request → FastAPI → Asset Registry (YAML) → DCAT + ODRL response
+```
+
+The asset registry is the single source of truth for what a station exposes. It maps abstract ODRL target URNs to concrete local resources:
+
+```yaml
+# station_assets.yaml (excerpt)
+assets:
+  "urn:pluginlake:dataset:omop_condition":
+    dagster_asset_key: ["omop", "condition_occurrence"]
+    ducklake_schema: "omop"
+    ducklake_table: "condition_occurrence"
+    available_columns: [condition_concept_id, condition_start_date, ...]
+    sensitive_columns: [person_id]  # never exposed externally
+    external: true   # appears in DSP catalog
+
+  "urn:pluginlake:dataset:omop_person":
+    dagster_asset_key: ["omop", "person"]
+    external: false  # internal only, hidden from DSP catalog
+```
+
+Only assets with `external: true` appear in the catalog response:
+
+```python
+@router.get("/dsp/catalog")
+async def get_catalog(registry: AssetRegistry = Depends(get_asset_registry)):
+    datasets = [
+        {"@type": "dcat:Dataset", "@id": urn, "odrl:hasPolicy": build_offer(asset)}
+        for urn, asset in registry.items() if asset.external
+    ]
+    return {"@type": "dcat:Catalog", "dcat:dataset": datasets}
+```
+
+---
+
+## DSP Negotiation ↔ Agreement Lifecycle + pluginlake database
+
+**DSP says:** Consumer and provider negotiate a contract. The provider can accept, reject, or counter-offer. Once FINALIZED, the agreement governs all subsequent data access.
+
+**pluginlake does:** The hub (consumer) initiates a negotiation. The station (provider) may require human approval from a station admin. The agreed ODRL policy is stored as JSON alongside the negotiation state. All subsequent requests are checked against this agreement.
+
+```
+Hub operator → Hub FastAPI → DSP ContractRequestMessage → Station FastAPI
+    → Station admin approves/tightens → DSP AgreementMessage → database
+```
+
+**Storage requirements:**
+- Transactional state machine (no partial state transitions — a negotiation is either REQUESTED or OFFERED, never both)
+- JSON storage for ODRL policies (variable structure, needs querying)
+- Foreign key relationship between negotiation and transfer records
+- Concurrent access from FastAPI workers + Dagster sensors
+
+**Current implementation:** `dsp` schema in the existing PostgreSQL instance (same container as Dagster and DuckLake metadata). This may move to DuckLake-managed tables or a dedicated DuckDB instance if the project moves away from Postgres.
+
+```sql
+-- Current: Postgres dsp schema
+CREATE TABLE dsp.negotiation (
+    id           UUID PRIMARY KEY,
+    consumer_id  TEXT NOT NULL,    -- Nuts DID of consumer org
+    dataset_id   TEXT,             -- primary asset URN
+    state        TEXT NOT NULL,
+    policy       JSONB,            -- ODRL policy agreed upon
+    ...
+);
+```
+
+**State machine** (provider-side, as defined by DSP 2025-1):
+
+```
+REQUESTED → OFFERED → AGREED → VERIFIED → FINALIZED → [active]
+    └→ TERMINATED (from any state)
+```
+
+**What the agreement sets vs what happens per-request:**
+
+| Resolved during negotiation (once) | Resolved per-request |
+|---|---|
+| Which datasets | Which specific user (in VC) |
+| Which operations allowed | Which columns returned (station applies) |
+| Purpose of use | Row filters (station applies) |
+| Agreement validity period | Privacy thresholds (station checks post-execution) |
+
+---
+
+## DSP Transfer ↔ Dagster Materialization
+
+**DSP says:** After an agreement exists, the consumer requests a data transfer. The provider executes it and provides access to results.
+
+**pluginlake does:** A transfer request triggers a Dagster asset materialization. A Dagster sensor monitors run completion and transitions the DSP state accordingly. On completion, a scoped token is issued for data retrieval from DuckLake.
+
+```
+Transfer request → validate agreement → trigger Dagster run
+    → sensor detects completion → issue scoped token → callback to consumer
+    → consumer GETs /dsp/data/{transfer_id} with token → DuckLake query result
+```
+
+**DSP state ↔ Dagster mapping:**
+
+| DSP state | What happens in pluginlake |
+|---|---|
+| REQUESTED | Agreement validated, transfer record created in database |
+| STARTED | `POST /api/assets/{key}/materialize` triggered, `dagster_run_id` stored |
+| COMPLETED | Sensor detects run SUCCESS, scoped JWT issued, callback sent to hub |
+| TERMINATED | Run FAILURE/CANCELED or consumer cancels; token revoked |
+
+**Key constraint:** DSP requires the provider to push state-change callbacks to the consumer even for pull transfers. This is why `consumer_callback` is stored per transfer.
+
+**Data access after completion:** The consumer receives a `DataAddress` containing a time-limited signed token and endpoint `GET /dsp/data/{transfer_id}`. This is a short-lived bearer token (not a VC) scoped to one transfer.
+
+---
+
+## Nuts VP ↔ FastAPI Middleware (boundary 2)
+
+**Nuts says:** Organizations prove identity via DPoP-bound access tokens. The calling node obtains a token from its local Nuts Node (which involves presenting VPs during the OAuth2 exchange). The token is sent per-request.
+
+**pluginlake does:** FastAPI middleware extracts the `Authorization` header, validates the DPoP proof against the local Nuts Node (localhost call, no network round-trip), and populates the request context with the authenticated organizational identity.
+
+```
+Hub request → Authorization: DPoP <token>
+    → FastAPI middleware → POST /internal/auth/v2/dpop/validate (local Nuts Node)
+    → request context: {organization_did, organization_name}
+    → route handler proceeds
+```
+
+This proves *which organization* is calling. It does not say anything about *which user* or *what they're allowed to do* — that's boundary 3 (the PluginlakeAccessCredential).
+
+---
+
+## PluginlakeAccessCredential ↔ Per-user Authorization (boundary 3)
+
+**ODRL says:** Permissions can be expressed as policies with actions, targets, and constraints.
+
+**pluginlake does:** The hub issues a Verifiable Credential to each researcher containing their permitted datasets, operations, and constraints (expressed as pluginlake's ODRL profile). The station verifies the VC signature, checks it references an active agreement, and extracts the claims for enforcement.
+
+```
+Researcher logs in at hub (OIDC) → hub issues PluginlakeAccessCredential
+    → researcher's request to station carries: Nuts DPoP token + VC (as VP)
+    → station verifies: signature, issuer trust, agreement reference, expiry
+    → station extracts: permitted datasets, operations, columns, constraints
+```
+
+The VC is issued by the hub's DID (signing key in the hub's DID document). The station trusts hub signing keys learned through the Nuts network.
+
+---
+
+## ODRL Profile ↔ Enforcement Layer
+
+**The enforcement problem:** Three independent sources of constraints must be merged into a single executable query:
+
+1. **Agreement** (from DSP negotiation) — outer bounds
+2. **VC** (from presented credential) — user-specific bounds
+3. **Station-local config** (from YAML) — station sovereignty
+
+**pluginlake's rule: most restrictive wins.** The enforcement layer intersects all three:
+
+```
+Agreement:   datasets=[omop_condition], ops=[aggregate, count], purpose=research
+VC claims:   datasets=[omop_condition], ops=[aggregate], columns=[concept_id, start_date]
+Station:     sensitive_columns=[person_id], min_k=5, max_rows=50000
+
+→ Enforced: table=omop.condition_occurrence, columns=[concept_id, start_date],
+            operation=aggregate, k-anonymity=5, person_id=DENIED
+```
+
+**The enforcement function** translates this into an executable query or Dagster job:
+
+```python
+def enforce_request(vc_claims, agreement, request, asset_registry, operation_registry, station_policy):
+    """Translate a verified request into a constrained executable query."""
+    # 1. Resolve ODRL target URN → local DuckLake table
+    # 2. Intersect permitted operations (agreement ∩ VC ∩ station)
+    # 3. Intersect permitted columns (available - sensitive ∩ VC-permitted)
+    # 4. Build constrained SQL or trigger Dagster job
+    # 5. Attach privacy checks (k-anonymity, max cardinality)
+    ...
+```
+
+**Operation registry** maps ODRL actions to concrete execution:
+
+```yaml
+# station_operations.yaml (excerpt)
+operations:
+  "pluginlake:aggregate":
+    type: sql_template
+    sql: "SELECT {columns}, COUNT(*) as n FROM {table} {where} GROUP BY {columns}"
+    min_group_size: 5
+
+  "pluginlake:federated_learning":
+    type: dagster_job
+    job_name: "fl_training_round"
+    allowed_parameters: [model_type, epochs, batch_size]
+```
+
+---
+
+## Governance models
+
+Three models control *who approves agreements*. Runtime enforcement is identical regardless of model.
+
+| Model | Who approves | Station autonomy |
+|---|---|---|
+| **Data holder governed** (default) | Station admin reviews each agreement | Full |
+| **Collaboration governed** | Coordinator pre-configures for all stations | Delegated (auto-accept) |
+| **Hybrid** | Collaboration sets baseline, station can only tighten | Preserved (can restrict, not relax) |
+
+**Station-local overrides are always authoritative.** A collaboration coordinator cannot override a station's local restrictions.
+
+---
+
+## Role-based access control
+
+### Processing hub roles
+
+| Role | Can do | Cannot do |
+|---|---|---|
+| **Network admin** | Initiate DSP negotiations, configure credential issuance, manage operators | Access research data, submit queries |
+| **Hub operator** | Add/remove researchers, map users to agreements, monitor | Initiate or approve agreements |
+| **Researcher** | Browse permitted catalog, submit queries within scope, view own results | Modify permissions, initiate agreements |
+
+### Data station roles
+
+| Role | Can do | Cannot do |
+|---|---|---|
+| **Station admin** | Accept/reject agreements, configure access policy, manage station | Override collaboration constraints to be more permissive |
+| **Station operator** | View agreements (read-only), monitor transfers and logs | Approve/reject agreements, modify policy |
+
+Example:
+
+```python
+@router.post("/dsp/negotiations")
+async def initiate_negotiation(request: ContractRequestMessage, user = Depends(require_role("network_admin"))):
+    ...
+
+@router.post("/dsp/negotiations/{id}/events")
+async def negotiation_event(id: UUID, event: NegotiationEvent, user = Depends(require_role("station_admin"))):
+    ...
+```
+
+For the full RBAC entity model, see [Part 2 below](#role-based-access-control-for-hub-and-station-operators).
+
+---
+
+## DSP protocol constraints
+
+Constraints imposed by DSP 2025-1 that affect pluginlake's implementation:
+
+| DSP constraint | pluginlake implication |
+|---|---|
+| JSON-LD mandatory | Pydantic models handle compacted form; `pyld` added if external connectors send expanded |
+| Provider must push state callbacks | `consumer_callback` stored per transfer; outbound HTTP even for pull transfers |
+| No negotiation timeout defined | pluginlake defines its own timeout policy (configurable) |
+| Messages use `@context`, `@type`, `@id` | Pydantic `Field(alias="@context")` pattern |
+
+---
+
+## DSP routes on FastAPI
+
+```
+# Internal routes (unchanged)
+GET  /api/catalog/schemas          → DuckLake schema listing
+GET  /api/catalog/tables           → DuckLake table listing
+POST /api/assets/{key}/materialize → Dagster run trigger
+
+# DSP routes (Eclipse Dataspace Protocol 2025-1 HTTPS bindings)
+GET  /.well-known/dataspace                            → Self-description
+GET  /dsp/catalog                                      → DCAT catalog (from asset registry)
+POST /dsp/catalog/request                              → Filtered catalog query
+POST /dsp/negotiations/request                         → Start negotiation
+GET  /dsp/negotiations/{providerPid}                   → Get negotiation state
+POST /dsp/negotiations/{providerPid}/events            → Accept/reject/counter
+POST /dsp/negotiations/{providerPid}/agreement/verification  → Verify agreement
+POST /dsp/negotiations/{providerPid}/termination       → Terminate
+POST /dsp/transfers/request                            → Start transfer
+GET  /dsp/transfers/{providerPid}                      → Get transfer state
+POST /dsp/transfers/{providerPid}/start                → Signal started
+POST /dsp/transfers/{providerPid}/completion           → Signal completed
+POST /dsp/transfers/{providerPid}/termination          → Terminate
+
+# Data access (post-transfer)
+GET  /dsp/data/{transfer_id}       → Pull result data (scoped token required)
+```
+
+---
+
+## Phased delivery
+
+### Phase 1: DSP provider + Nuts identity
+
+**Goal:** One station receives DSP requests from one hub, authenticated via Nuts. Contract negotiation works end-to-end.
+
+**Delivers:**
+- `src/pluginlake/dsp/`: DSP provider routes (catalog, negotiation, transfer)
+- Nuts middleware for org identity verification
+- Negotiation state machine (`dsp` schema)
+- Transfer → Dagster materialization → scoped token
+- Station asset registry (YAML)
+- Integration test client (simulates hub)
+
+**Does not include:** hub-side DSP client, per-user VCs, ODRL evaluation, multi-hub, RBAC dashboard.
+
+### Phase 2: Per-user credentials + ODRL enforcement
+
+**Goal:** Per-user authorization at the station.
+
+**Delivers:**
+- `src/pluginlake/authz/`: ODRL evaluator, VC verification, enforcement
+- PluginlakeAccessCredential schema (ADR-008)
+- Hub issues VCs, station verifies per-request
+- Operation registry (YAML → SQL templates / Dagster jobs)
+- Constraint enforcement (columns, rows, privacy)
+- Multi-hub topology
+
+### Phase 3: UI + governance + collaboration
+
+**Goal:** Production-ready multi-org network.
+
+**Delivers:**
+- Hub UI (Streamlit): credential issuance, agreement monitoring
+- Station UI (Streamlit): access control dashboard, approval workflow
+- RBAC entity model
+- Governance models (data holder, collaboration, hybrid)
+- Audit trail + decision logging
+- Credential revocation (StatusList2021)
+
+
+---
+
+# Part 2: Options analysis, UX workflows, and deep-dive reference
+
+The following sections preserve the detailed options analysis, dashboard UX workflows, RBAC entity model, governance models, and international standards appendix from the original architecture evaluation.
+
+---
+
+## Options analysis: authentication and authorization architecture
+
+> **Editorial note:** This section documents the five options evaluated during the architecture design process. The initial recommendation was Option A (Nuts + OPA). Through iterative design, the architecture evolved to a **VC-native ODRL approach** (a refined variant of Option D) that eliminates OPA entirely. The adopted architecture is described in the "Enforcement" section below. This analysis is preserved to document why each alternative was considered and rejected.
+
+Five options were evaluated. All assume DSP for the protocol layer. They differ in how trust boundaries 2 and 3 are handled.
+
+### Option A: Nuts + OPA with pluginlake user context token (initially recommended)
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant H as Processing Hub
+    participant HOPA as Hub OPA
+    participant N as Nuts middleware
+    participant S as Data Station
+    participant SOPA as Station OPA
+    participant DL as DuckLake
+
+    R->>H: OIDC login + request
+    H->>HOPA: evaluate user permissions
+    HOPA-->>H: permitted datasets, operations, constraints
+    H->>H: mint signed user context JWT
+    H->>N: DSP request + Nuts token + user context JWT
+    N->>N: validate org identity (hub DID + NutsOrgCred)
+    N->>S: verified, proceed
+    S->>S: verify user context JWT signature
+    S->>SOPA: nuts_claims + user_context + request
+    SOPA-->>S: allow + constraints (tables, columns, rows, compute)
+    S->>DL: constrained query/compute
+    DL-->>S: results
+    S-->>H: transfer data
+    H-->>R: results
+```
+
+**How Nuts is used:** Strictly for inter-node organizational identity (trust boundary 2). Answers one question: "is this hub a known participant in the pluginlake network?" Once verified, Nuts is done. No fine-grained permissions in the Nuts token.
+
+**How OPA is used:** For all fine-grained access control (trust boundary 3). The hub's OPA computes permitted datasets, operations, and constraints for the user, then mints a signed JWT. The station's OPA evaluates the JWT claims against the request and its own policy. OPA runs as a sidecar on both hub and station.
+
+**The pluginlake user context token** is a JWT signed by the hub, containing:
+
+```json
+{
+  "iss": "did:nuts:hubA",
+  "aud": "did:nuts:stationX",
+  "hub_id": "hub-A",
+  "hub_did": "did:nuts:hubA",
+  "user_id": "researcher-Y",
+  "purpose": "urn:pluginlake:purpose:observational-research",
+  "agreement_id": "abc123",
+  "permitted_datasets": ["omop_condition", "omop_observation"],
+  "permitted_operations": ["aggregate", "query"],
+  "iat": 1234567890,
+  "exp": 1234568190
+}
+```
+
+**Security requirements for the user context JWT:**
+
+- `aud` (audience) is **mandatory** -- prevents cross-station replay attacks. A JWT issued for Station X cannot be presented to Station Y.
+- `iss` (issuer) must match the hub's DID as registered in the Nuts network.
+- `exp` is set to cover the expected request duration (default: 5 minutes). The station validates the JWT **at request initiation only** -- once the Dagster run starts, the JWT is not re-checked during execution. The agreement validity (not JWT expiry) governs long-running jobs.
+- The station must reject JWTs where `aud` does not match its own DID.
+
+**Why Nuts and OPA do not overlap:**
+
+| Question | Answered by | Not answered by |
+|---|---|---|
+| Is this node a network participant? | Nuts | OPA |
+| Which organization operates this node? | Nuts | OPA |
+| What datasets can this user access? | OPA | Nuts |
+| What columns/rows are permitted? | OPA | Nuts |
+| What compute operations are allowed? | OPA | Nuts |
+| What is the purpose of this request? | OPA | Nuts |
+
+**Benefits:**
+- Clean separation: zero functional overlap between Nuts and OPA
+- Per-user, per-dataset, per-operation audit trail at the station (satisfies EHDS and DPO requirements)
+- Compute constraints (column filters, row filters, aggregation-only, privacy checks) are first-class
+- Station has independent enforcement -- does not fully trust the hub
+- Dynamic permissions without DSP contract renegotiation
+- OPA is CNCF-graduated, production-grade, sub-millisecond evaluation
+- Interoperable with Dutch healthcare ecosystem via Nuts
+
+**Drawbacks:**
+- Custom user context token format must be standardized (candidate for ADR-008)
+- Hub signing key management is an operational concern
+- OPA sidecar adds a deployment component per station and per hub
+- JSON-LD credentials must be flattened before passing to OPA (no native JSON-LD in Rego)
+- Not DSP-native -- the user context token is pluginlake-specific
+- Three sidecars per station (Nuts node, OPA, Dagster code server) increases operational complexity
+
+**Verdict:** Initially recommended. Provides the enforcement granularity required by EHDS and hospital DPOs. Through iterative design, this evolved into the adopted VC-native ODRL approach which achieves the same enforcement without the OPA sidecar dependency.
+
+---
+
+### Option B: OPA only, no Nuts (mTLS + internal PKI)
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant H as Processing Hub
+    participant HOPA as Hub OPA
+    participant S as Data Station
+    participant SOPA as Station OPA
+    participant DL as DuckLake
+
+    R->>H: OIDC login + request
+    H->>HOPA: evaluate user permissions
+    HOPA-->>H: permitted datasets, operations, constraints
+    H->>H: mint signed user context JWT
+    H->>S: mTLS + DSP request + user context JWT
+    S->>S: validate client certificate (PKI)
+    S->>S: verify user context JWT signature
+    S->>SOPA: org_claims + user_context + request
+    SOPA-->>S: allow + constraints
+    S->>DL: constrained query/compute
+    DL-->>S: results
+    S-->>H: transfer data
+```
+
+**How org identity works without Nuts:** mTLS with a shared PKI. Each pluginlake instance has a client certificate signed by a pluginlake CA (managed by DHD). The station validates the certificate chain to verify the hub is a known participant. Network membership is managed by certificate issuance/revocation.
+
+**Benefits:**
+- Simpler infrastructure: no Nuts node sidecar per station
+- No dependency on Nuts network availability
+- No Bolt definition or Nuts community governance required
+- mTLS is well-understood, widely supported
+- All fine-grained enforcement in OPA -- single policy system
+
+**Drawbacks:**
+- Not interoperable with the broader Dutch healthcare ecosystem (Nuts is the direction for NL health dataspaces)
+- PKI certificate management is a significant operational burden (issuance, rotation, revocation, HSMs)
+- Network membership is centralized in the CA -- DHD becomes a single point of authority
+- No decentralized identity -- cannot interoperate with external dataspaces using VCs
+- Does not align with EHDS direction toward decentralized trust frameworks
+- No discovery mechanism -- stations must be configured with known hub certificates manually
+
+**Verdict:** Technically simpler but strategically weak. Choosing this option means pluginlake cannot participate in the broader Dutch health dataspace ecosystem that is converging on Nuts. Only appropriate if pluginlake will always be a closed, DHD-managed network with no external interoperability requirement.
+
+---
+
+### Option C: Nuts only, no OPA
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant H as Processing Hub
+    participant N as Nuts middleware
+    participant S as Data Station
+    participant DL as DuckLake
+
+    R->>H: OIDC login + request
+    H->>N: DSP request + Nuts token
+    N->>N: validate org identity
+    N->>S: verified, proceed
+    S->>DL: query (org-level access only)
+    DL-->>S: results
+    S-->>H: transfer data
+```
+
+**Benefits:**
+- Simplest architecture: one auth system
+- Fully decentralized, no custom token format
+- Interoperable with NL health ecosystem
+
+**Drawbacks:**
+- No per-user visibility at the station. DPO cannot audit which researcher accessed data.
+- No per-dataset access control beyond Nuts scope
+- No compute constraints -- Nuts cannot express "aggregate only, no extraction"
+- Hub must be fully trusted to enforce all fine-grained access. Station has no independent enforcement.
+- Does not satisfy EHDS Article 50+ requirements for auditing which data user accessed which data for which purpose.
+
+**Verdict:** Insufficient for a research data platform where legal data sharing agreements are per researcher and per purpose.
+
+---
+
+### Option D: Nuts + ODRL policy evaluation (DSP-native)
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant H as Processing Hub
+    participant N as Nuts middleware
+    participant S as Data Station
+    participant ODRL as ODRL engine
+    participant DL as DuckLake
+
+    R->>H: OIDC login + request
+    H->>N: DSP contract negotiation with ODRL policy
+    N->>S: verified
+    S->>S: store DSP Agreement with ODRL
+    Note over S: transfer request arrives later
+    S->>ODRL: evaluate ODRL policy against request
+    ODRL-->>S: allow/deny
+    S->>DL: query
+    DL-->>S: results
+    S-->>H: transfer data
+```
+
+**Benefits:**
+- Fully standards-compliant (DSP + ODRL)
+- No custom token format
+- Interoperable with any DSP connector supporting ODRL
+
+**Drawbacks:**
+- ODRL cannot natively express compute constraints (column allowlists, row filters, max cardinality, privacy checks). Custom ODRL profiles needed, reducing interoperability.
+- No existing Python ODRL evaluation library for the full spec
+- Every permission change requires renegotiating a DSP contract
+- Contract explosion: new agreement per user × per dataset × per purpose
+- ODRL deontic conflict resolution (prohibition overrides permission) must be built from scratch
+
+**Verdict:** Elegant in theory but impractical for v1 as originally scoped. However, through iterative design, a constrained version of this approach (Level 2 ODRL profile with built-in evaluator, VC-based credentials instead of custom JWT) became the adopted architecture. See the "Enforcement" section for the final design.
+
+---
+
+### Option E: No Nuts, no OPA (API keys + application-level enforcement)
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant H as Processing Hub
+    participant S as Data Station
+    participant DL as DuckLake
+
+    R->>H: login + request
+    H->>S: API key + request
+    S->>S: validate API key
+    S->>S: application-code access check
+    S->>DL: query
+    DL-->>S: results
+    S-->>H: transfer data
+```
+
+**Benefits:**
+- Simplest possible implementation
+- No external dependencies
+- Fast to prototype
+
+**Drawbacks:**
+- No organizational identity verification
+- No interoperability with any external dataspace
+- No decentralized trust -- fully centralized API key management
+- Security model equivalent to a shared password
+- Does not satisfy any EHDS, Health-RI, or DSP requirement
+- Not viable for a multi-organization network
+
+**Verdict:** Only suitable for local development and testing. Not an option for production.
+
+---
+
+### Options comparison
+
+| Criterion | A: Nuts+OPA | B: OPA only | C: Nuts only | D: Nuts+ODRL (adopted) | E: API keys |
+|---|---|---|---|---|---|
+| NL health ecosystem interop | ✓ | ✗ | ✓ | ✓ | ✗ |
+| Per-user audit at station | ✓ | ✓ | ✗ | Partial | ✗ |
+| Compute constraints | ✓ | ✓ | ✗ | ✗ | ✗ |
+| EHDS compliance | ✓ | Partial | ✗ | ✓ | ✗ |
+| DSP standards compliance | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Decentralized identity | ✓ | ✗ | ✓ | ✓ | ✗ |
+| Operational complexity | High | Medium | Low | High | Low |
+| Custom token format needed | Yes | Yes | No | No | No |
+| External dataspace interop | ✓ | ✗ | ✓ | ✓ | ✗ |
+
+---
+
+## Contract negotiation scenarios
+
+Once a DSP agreement is FINALIZED, it covers all subsequent requests within its scope. Individual queries and compute requests do NOT require re-negotiation — they reference the existing agreement and present a VC proving authorization within that agreement's terms.
+
+### Scenario 1: Hub-initiated, bilateral approval (default)
+
+The processing hub initiates the contract and sends it to the data station. The station must explicitly approve before the agreement is active. This is the standard DSP flow.
+
+```mermaid
+sequenceDiagram
+    participant HO as Hub operator
+    participant HUB as Processing Hub
+    participant STA as Data Station
+    participant SO as Station admin
+
+    Note over HO,SO: ONE-TIME: Contract negotiation
+    HO->>HUB: "Request access to omop_condition<br/>on Station X for scientific research"
+    HUB->>STA: DSP ContractRequestMessage<br/>(datasets, ODRL terms, purpose)
+    STA->>SO: notification: "Hub A requests access"
+    Note over SO: Station admin reviews:<br/>• who is requesting (hub identity via Nuts)<br/>• which datasets<br/>• proposed terms and constraints<br/>• stated purpose
+    SO->>STA: approve (possibly with tighter constraints)
+    STA->>STA: store agreement #123 (FINALIZED)
+    STA->>HUB: DSP AgreementMessage
+    HUB->>HUB: store agreement #123 (FINALIZED)
+    Note over HO,SO: Agreement is now active at both sides
+
+    Note over HO,SO: PER-REQUEST: No re-negotiation needed
+    HUB->>STA: request + VP (org credential + access VC)<br/>VC references agreement_id: #123
+    STA->>STA: verify VC + check agreement #123 active + apply local rules
+    STA-->>HUB: results (within constraints)
+    Note over STA: Repeat N times without re-negotiation
+```
+
+**Key properties:**
+- Hub cannot access anything until station explicitly approves
+- Station stores the agreement — knows exactly what it agreed to
+- Every subsequent request references this agreement
+- Station can terminate agreement at any time (immediate effect)
+- Hub can request access to additional datasets → new negotiation required
+
+### Scenario 2: Hub-initiated with station counter-offer
+
+The station may not accept the hub's proposed terms as-is. It can counter-offer with tighter constraints. The hub must then accept the modified terms.
+
+```mermaid
+sequenceDiagram
+    participant HUB as Processing Hub
+    participant STA as Data Station
+    participant SO as Station admin
+
+    HUB->>STA: DSP ContractRequestMessage<br/>"I want omop_condition + omop_drug_exposure,<br/>all columns, purpose: any research"
+    STA->>SO: notification with proposed terms
+    Note over SO: Station admin decides:<br/>• omop_condition: OK but not person_id column<br/>• omop_drug_exposure: DENIED entirely<br/>• purpose must be scientific only (not commercial)
+    SO->>STA: counter-offer with restrictions
+    STA->>HUB: DSP ContractOfferMessage<br/>(modified: omop_condition only,<br/>exclude person_id, scientific purpose only)
+    HUB->>HUB: Hub operator reviews counter-offer
+    HUB->>STA: DSP ContractNegotiationEventMessage (ACCEPTED)
+    STA->>STA: store agreement #456 (FINALIZED)
+    STA->>HUB: DSP AgreementMessage
+    HUB->>HUB: store agreement #456 (FINALIZED)
+    Note over HUB,STA: Agreement reflects STATION's terms, not hub's original request
+```
+
+**Key properties:**
+- Station has full power to modify terms before agreeing
+- Hub sees exactly what was approved (no surprises at request time)
+- The finalized agreement is the station's version, not the hub's proposal
+- Constraints in the agreement are the MAXIMUM the hub can request — station can still apply additional restrictions at query time
+
+### What the agreement covers vs what happens per-request
+
+| Concern | Resolved during negotiation (one-time) | Resolved per-request (every query) |
+|---|---|---|
+| Which datasets | ✓ (in agreement) | |
+| Which operations allowed | ✓ (in agreement) | |
+| Purpose of use | ✓ (in agreement) | |
+| Agreement valid until | ✓ (in agreement) | |
+| Which specific user | | ✓ (in VC presented with request) |
+| Which columns returned | | ✓ (station applies at query time) |
+| Row filters | | ✓ (station applies at query time) |
+| Privacy thresholds (k-anon) | | ✓ (station checks post-execution) |
+| Result size limits | | ✓ (station enforces per-query) |
+
+The agreement sets the outer bounds. Per-request enforcement narrows further based on the specific VC claims + station-local policy.
+
+### Agreement lifecycle
+
+```
+REQUESTED ──→ OFFERED ──→ AGREED ──→ VERIFIED ──→ FINALIZED ──→ [active]
+    │              │           │                        │              │
+    └──→ TERMINATED (station rejects)                   │          TERMINATED
+         TERMINATED (hub withdraws)                     │       (station revokes
+                                                        │        or agreement expires)
+                                                        │
+                                              Per-request access works
+                                              without re-negotiation
+```
+
+---
+
+## Practical workflow: dashboard UX for hub and station operators
+
+The architecture above translates into concrete management flows for three user types: station operators (hospital IT/data stewards), hub operators (network/collab administrators), and researchers.
+
+### Station operator workflow
+
+A station operator manages their data station through a station dashboard (part of the pluginlake UI).
+
+**Joining a network:**
+
+```mermaid
+sequenceDiagram
+    participant SO as Station operator
+    participant SD as Station dashboard
+    participant NUTS as Station Nuts node
+    participant DS as DHD Discovery Service
+
+    SO->>SD: "Join pluginlake network"
+    SD->>NUTS: generate DID + keypair
+    NUTS-->>SD: did:nuts:stationA
+    SO->>SD: enter organization details (URA, name)
+    SD->>NUTS: request NutsOrganizationCredential issuance
+    NUTS->>DS: register VP on discovery service
+    DS-->>SD: registered, station visible to hubs
+    SD-->>SO: "Station is live on the network"
+```
+
+**Approving a hub connection:**
+
+When a hub initiates a DSP contract negotiation with the station, the station operator sees an approval request in the dashboard:
+
+```mermaid
+sequenceDiagram
+    participant HUB as Processing Hub
+    participant SD as Station dashboard
+    participant SO as Station operator
+    participant PG as Postgres (dsp schema)
+
+    HUB->>SD: DSP ContractRequestMessage (dataset, ODRL policy)
+    SD->>PG: store negotiation (state: REQUESTED)
+    SD->>SO: notification: "Hub A requests access to omop_condition"
+    Note over SD: Shows: hub org identity, requested datasets,<br/>proposed ODRL policy, purpose
+    SO->>SD: review terms, modify constraints if needed
+    SO->>SD: approve / reject
+    alt Approved
+        SD->>PG: update state: AGREED → VERIFIED → FINALIZED
+        SD->>PG: store agreement with ODRL terms
+        SD->>HUB: DSP AgreementMessage
+    else Rejected
+        SD->>PG: update state: TERMINATED
+        SD->>HUB: DSP TerminationMessage (reason)
+    end
+```
+
+**Configuring station-level access constraints:**
+
+The station dashboard provides a policy editor where the data holder can configure:
+
+- Which datasets are externally visible in the DSP catalog (Dagster tag `pluginlake/external: "true"`)
+- Per-dataset column allowlists/denylists
+- Row filter conditions (e.g. date ranges, minimum cohort sizes)
+- Privacy thresholds (k-anonymity, differential privacy budget)
+- Compute restrictions (aggregate-only, no raw extraction)
+- Station-local overrides (datasets never shared regardless of agreement)
+
+These settings are stored in the station's asset registry (`station_assets.yaml`) and operation registry (`station_operations.yaml`). Changes take effect on the next request (no reload delay).
+
+### Hub operator workflow
+
+A hub operator manages the processing hub, its connected stations, and its users.
+
+**Connecting to a station:**
+
+```mermaid
+sequenceDiagram
+    participant HO as Hub operator
+    participant HD as Hub dashboard
+    participant DS as DHD Discovery Service
+    participant HUB as Hub (DSP client)
+    participant STA as Target Station
+
+    HO->>HD: "Browse available stations"
+    HD->>DS: query discovery service
+    DS-->>HD: list of registered stations (DID, org, endpoints)
+    HO->>HD: select Station B, initiate connection
+    HD->>HUB: start DSP contract negotiation
+    HUB->>STA: DSP ContractRequestMessage
+    Note over STA: Station operator reviews and approves (see above)
+    STA-->>HUB: DSP AgreementMessage
+    HD-->>HO: "Connected to Station B, agreement active"
+```
+
+**Managing users:**
+
+The hub dashboard provides user management:
+
+- Add/remove researchers (OIDC accounts via hub's IdP or federated)
+- Assign roles (analyst, lead researcher, admin)
+- Map users to agreements: which user is authorized to use which active DSP agreement
+- Set per-user purpose constraints (user X can only make requests for purpose "observational research")
+
+These settings feed into the hub's credential issuance logic. When a researcher makes a request, the hub checks their identity + role against the active agreements and permitted purposes, then issues a PluginlakeAccessCredential (VC) scoped to those permissions.
+
+**Monitoring activity:**
+
+The hub dashboard shows:
+
+- Active agreements with each station and their status
+- Recent transfer requests and their outcomes
+- Decision logs: which requests were allowed/denied and why
+- Dagster run status for active transfers
+
+### Researcher workflow
+
+A researcher interacts with the processing hub through a research interface (e.g. Streamlit app, Jupyter gateway, or dedicated UI).
+
+```mermaid
+sequenceDiagram
+    participant R as Researcher
+    participant UI as Hub research UI
+    participant HUB as Hub (authz + DSP/Dagster)
+    participant STA as Station A
+
+    R->>UI: login (OIDC)
+    R->>UI: browse available datasets
+    UI->>HUB: what can this user see?
+    HUB-->>UI: filtered catalog (only datasets user has agreements for)
+    R->>UI: submit query (aggregate omop_condition by year)
+    UI->>HUB: evaluate: can user do this?
+    HUB-->>HUB: check user role + agreement → issue VC
+    HUB->>STA: Nuts VP (org credential + access VC) + request
+    STA->>STA: verify VC + check agreement + enforce constraints
+    STA->>STA: execute constrained DuckLake query
+    STA-->>HUB: results
+    HUB-->>UI: display results
+    UI-->>R: "Query complete, 847 rows returned"
+```
+
+The researcher never sees Nuts tokens, VC verification, or DSP negotiations. They see a catalog of available data (pre-filtered by their permissions) and submit queries. The authorization is invisible.
+
+### How approval flows connect the components
+
+```mermaid
+graph TD
+    subgraph "One-time setup"
+        A1[Station joins network<br/>Nuts DID + discovery registration]
+        A2[Hub joins network<br/>Nuts DID + discovery registration]
+        A3[Hub discovers station<br/>via discovery service]
+        A4[Hub initiates DSP negotiation<br/>with station]
+        A5[Station operator approves<br/>agreement terms]
+    end
+    subgraph "Per-user setup"
+        B1[Hub operator adds researcher<br/>OIDC account + role]
+        B2[Hub operator maps user<br/>to active agreement]
+        B3[Hub credential issuance configured<br/>user can now make requests]
+    end
+    subgraph "Per-request runtime"
+        C1[Researcher submits query]
+        C2[Hub issues VC with<br/>ODRL permissions for user]
+        C3[Station verifies VC +<br/>enforces constraints]
+        C4[DuckLake executes<br/>constrained query]
+    end
+    A1 --> A3
+    A2 --> A3
+    A3 --> A4
+    A4 --> A5
+    A5 --> B2
+    B1 --> B2
+    B2 --> B3
+    B3 --> C1
+    C1 --> C2
+    C2 --> C3
+    C3 --> C4
+```
+
+## Governance models: who approves access
+
+### The problem: approval authority varies by network
+
+The architecture must not hardcode who approves access. In practice, three governance models exist and a single pluginlake deployment may encounter all three:
+
+**Model 1: Data holder governed.** The hospital's DPO or data steward decides what leaves their station. The station operator reviews and approves each DSP contract negotiation individually. This is the default model described in EHDS Article 50+ and the Health-RI data station specification.
+
+**Model 2: Collaboration governed.** A research consortium or network coordinator defines the access terms upfront for all stations in the network. Individual station operators do not approve each request -- they delegate that authority to the collaboration when joining. The collaboration coordinator configures which hubs can access which datasets across all stations.
+
+**Model 3: Hybrid.** The collaboration sets baseline access terms, but individual station operators can add restrictions (never share certain columns, require higher k-anonymity). The collaboration cannot override station-local constraints -- data holder sovereignty is preserved.
+
+### How this maps to DSP + VC enforcement
+
+The DSP Agreement is the formal artifact that captures the approved access terms regardless of who approved them. The approval workflow differs, but the runtime enforcement is identical:
+
+```mermaid
+graph TD
+    subgraph "Model 1: Data holder governed"
+        H1[Hub requests access] --> S1[Station operator reviews]
+        S1 --> A1[Station operator approves/rejects]
+        A1 --> DSP1[DSP Agreement FINALIZED]
+    end
+    subgraph "Model 2: Collaboration governed"
+        CC[Collaboration coordinator<br/>configures network-wide access] --> PRE[Pre-approved agreements<br/>pushed to all stations]
+        PRE --> DSP2[DSP Agreement FINALIZED]
+    end
+    subgraph "Model 3: Hybrid"
+        CC2[Collaboration sets baseline] --> S2[Station operator reviews<br/>can add restrictions only]
+        S2 --> DSP3[DSP Agreement FINALIZED<br/>baseline + station overrides]
+    end
+    DSP1 --> RT[Runtime: identical<br/>Nuts VP + VC presented<br/>→ station enforces via ODRL evaluator]
+    DSP2 --> RT
+    DSP3 --> RT
+```
+
+Once a DSP Agreement is FINALIZED — regardless of who finalized it — the VC-based enforcement works identically. The station verifies the VC, cross-references the agreement, and applies its own constraints. It does not need to know whether the agreement was approved by a local operator or pushed by a collaboration coordinator.
+
+### The collaboration coordinator role
+
+In Model 2 and Model 3, a new role exists: the collaboration coordinator. This is an operator with network-wide visibility who can:
+
+- Define which hubs participate in the collaboration
+- Define which datasets across which stations are in scope
+- Pre-configure DSP agreements for all station-hub pairs in the network
+- Configure credential issuance rules that reflect the collaboration's access terms
+
+The collaboration coordinator operates through the hub dashboard (or a dedicated governance UI) and pushes pre-approved agreements to stations. Stations in Model 2 auto-accept these agreements (the station's Nuts Bolt policy includes the collaboration's credential as a trusted issuer). Stations in Model 3 receive the agreement as a proposal that the local operator can only tighten, not relax.
+
+### Translating approval into transaction-level verification
+
+The formal contract approval process (DSP negotiation → FINALIZED agreement) translates directly into transaction-level verification of fine-grained permissions:
+
+```
+Approval (one-time, any governance model)
+  → DSP Agreement stored in both hub and station Postgres
+  → Agreement contains: datasets, operations, purpose, ODRL policy terms
+  → Agreement ID referenced in every subsequent transaction
+
+Transaction (per-request, runtime)
+  → Hub checks user against agreement → issues VC with agreement_id + ODRL permissions
+  → Station verifies VC signature + checks agreement_id against stored agreement
+  → If agreement is active + not expired + constraints satisfied → allow
+  → ODRL evaluator applies fine-grained constraints from agreement + VC + station config
+  → DuckLake query executes within bounds
+  → Decision logged with agreement_id for audit
+```
+
+Every transaction is traceable back to the formal agreement that authorized it. The agreement_id in the VC is the link between the governance approval and the runtime enforcement. This satisfies the EHDS requirement that every secondary use of health data is traceable to a specific permit.
+
+### Station-local overrides are always authoritative
+
+Regardless of governance model, the data holder retains sovereignty. Station-local restrictions (in `station_assets.yaml` and `station_operations.yaml`) can deny access that the collaboration or agreement would otherwise allow. This is enforced architecturally: the ODRL evaluator intersects VC claims with station-local config, and the most restrictive combination wins. The collaboration coordinator cannot push configuration that overrides local restrictions.
+
+This means:
+- A collaboration can grant access to `omop_condition` across all stations
+- But if Hospital A's asset registry marks `person_id` as a sensitive column, that column is never returned from Station A regardless of what the agreement says
+- The enforcement layer applies this at query time
+- The hub and collaboration coordinator see the denial in the decision log but cannot override it
+
+## Role-based access control for hub and station operators
+
+### The problem
+
+DSP contract negotiations and agreement approvals are high-stakes operations -- they define what data leaves a hospital and under what terms. These operations must be restricted to operators with explicit authority. A researcher must never be able to initiate or approve a DSP agreement. A junior hub operator must not be able to modify network-wide collaboration policies.
+
+### Proposed roles
+
+Two separate RBAC hierarchies exist: one for the processing hub, one for the data station. They are managed independently -- a person may hold roles on both, but the roles do not inherit across systems.
+
+#### Processing hub roles
+
+| Role | Can do | Cannot do |
+|---|---|---|
+| **Network admin** | Initiate DSP negotiations with stations. Accept/reject agreements. Configure collaboration-wide access policies. Manage hub operator accounts. Configure credential issuance rules. | Access research data. Submit queries. |
+| **Hub operator** | Add/remove researchers. Map users to active agreements. Assign user roles and purpose constraints. View decision logs. Monitor transfer status. | Initiate or approve DSP agreements. Modify collaboration-wide policies. |
+| **Researcher** | Browse permitted catalog. Submit queries/analytics within their permitted scope. View own results. | See other users' results. Modify permissions. Initiate agreements. See full decision logs. |
+
+#### Data station roles
+
+| Role | Can do | Cannot do |
+|---|---|---|
+| **Station admin** | Accept/reject incoming DSP agreement requests. Configure station-level access policy (column allowlists, row filters, privacy thresholds via asset/operation registry). Add station-local overrides. Register/deregister station on discovery service. Manage station operator accounts. | Override collaboration-level agreements to be more permissive (can only tighten). |
+| **Station operator** | View incoming agreement requests (read-only). Monitor active transfers and decision logs. View station health and Dagster run status. | Approve/reject agreements. Modify station policy. |
+
+### Agreement approval workflow with role enforcement
+
+```mermaid
+sequenceDiagram
+    participant NA as Network admin (hub)
+    participant HUB as Processing Hub
+    participant STA as Data Station
+    participant SA as Station admin
+    participant PG as Postgres (dsp schema)
+
+    NA->>HUB: initiate DSP negotiation with Station B<br/>(requires: network_admin role)
+    HUB->>STA: DSP ContractRequestMessage
+    STA->>PG: store negotiation (state: REQUESTED)
+    STA->>SA: notification: agreement request from Hub A
+    Note over SA: Station admin reviews:<br/>hub identity, datasets, ODRL terms, purpose
+    SA->>STA: approve with constraints<br/>(requires: station_admin role)
+    STA->>PG: state: FINALIZED
+    STA->>HUB: DSP AgreementMessage
+    HUB->>PG: store agreement
+    Note over NA: Network admin can now map<br/>researchers to this agreement
+    NA->>HUB: map researcher Y to agreement<br/>(requires: network_admin role)
+    Note over HUB: Hub operator can then manage<br/>day-to-day user assignments
+```
+
+### Role verification at the API level
+
+Every DSP-related endpoint on the FastAPI gateway checks the caller's role before proceeding:
+
+```python
+# Hub-side: only network_admin can initiate negotiations
+@router.post("/dsp/negotiations")
+async def initiate_negotiation(
+    request: ContractRequestMessage,
+    user: User = Depends(require_role("network_admin"))
+):
+    ...
+
+# Station-side: only station_admin can approve/reject
+@router.post("/dsp/negotiations/{id}/events")
+async def negotiation_event(
+    id: UUID,
+    event: NegotiationEvent,
+    user: User = Depends(require_role("station_admin"))
+):
+    ...
+
+# Hub-side: hub_operator or network_admin can map users to agreements
+@router.post("/api/users/{user_id}/agreements")
+async def assign_user_agreement(
+    user_id: str,
+    assignment: AgreementAssignment,
+    user: User = Depends(require_role("hub_operator", "network_admin"))
+):
+    ...
+```
+
+### Audit trail for administrative actions
+
+All role-gated actions are logged separately from per-transaction decision logs:
+
+- Who initiated the negotiation, when, with which station
+- Who approved/rejected the agreement, when, with what modifications
+- Who mapped which researcher to which agreement
+- Who modified station access policy (asset registry, operation registry) and what changed
+
+This administrative audit trail is distinct from the per-transaction enforcement decision log. Together they provide full traceability from governance decision to data access.
+
+### Identity and RBAC data model
+
+The RBAC model is anchored on organizations, not on individual pluginlake instances. A user belongs to an organization and can be granted roles on any instance (hub or station) that the organization operates. Nuts DIDs tie instances to organizations, and the same organizational identity in Nuts enables cross-instance role assignment within that org.
+
+#### Entity model
+
+```mermaid
+erDiagram
+    ORGANIZATION ||--o{ PLUGINLAKE_INSTANCE : operates
+    ORGANIZATION ||--o{ USER : employs
+    USER ||--o{ ROLE_ASSIGNMENT : has
+    PLUGINLAKE_INSTANCE ||--o{ ROLE_ASSIGNMENT : scoped_to
+    PLUGINLAKE_INSTANCE ||--o| NUTS_DID : identified_by
+    COLLABORATION ||--o{ COLLABORATION_MEMBER : includes
+    ORGANIZATION ||--o{ COLLABORATION_MEMBER : participates_in
+    COLLABORATION ||--o{ PLUGINLAKE_INSTANCE : governs
+    ROLE_ASSIGNMENT }o--|| ROLE : references
+
+    ORGANIZATION {
+        uuid id PK
+        string name
+        string ura_number "URA / AGB / KvK identifier"
+        string nuts_org_credential_id "links to Nuts org identity"
+    }
+
+    PLUGINLAKE_INSTANCE {
+        uuid id PK
+        uuid organization_id FK
+        string instance_type "hub | station"
+        string nuts_did "did:nuts:xxxxx"
+        string dsp_endpoint "https://station-a.example.org/dsp"
+        string status "active | decommissioned"
+    }
+
+    NUTS_DID {
+        string did PK
+        uuid instance_id FK
+        jsonb key_material "reference to Nuts node keystore"
+    }
+
+    USER {
+        uuid id PK
+        uuid organization_id FK
+        string email
+        string display_name
+        string oidc_subject "sub claim from IdP"
+        boolean active
+    }
+
+    ROLE {
+        string name PK "network_admin | hub_operator | station_admin | station_operator | researcher"
+        string scope_type "hub | station | organization"
+        text description
+    }
+
+    ROLE_ASSIGNMENT {
+        uuid id PK
+        uuid user_id FK
+        string role_name FK
+        uuid instance_id FK "nullable - null means org-wide"
+        uuid granted_by FK "user who granted this role"
+        timestamptz granted_at
+        timestamptz expires_at "nullable"
+    }
+
+    COLLABORATION {
+        uuid id PK
+        string name
+        uuid coordinating_org_id FK "org that manages the collab"
+        string nuts_did "collab hub DID if applicable"
+    }
+
+    COLLABORATION_MEMBER {
+        uuid collaboration_id FK
+        uuid organization_id FK
+        string member_role "coordinator | participant"
+        timestamptz joined_at
+    }
+```
+
+#### Role definitions and scope
+
+Roles are scoped at three levels: organization-wide, per-hub, or per-station. A role assignment with `instance_id = null` applies to all instances operated by that organization.
+
+| Role | Scope | Description |
+|---|---|---|
+| `network_admin` | hub | Initiate/approve DSP negotiations. Configure collaboration-wide access policies. Manage hub operators and researchers. Configure credential issuance rules. |
+| `hub_operator` | hub | Add/remove researchers. Map users to agreements. Monitor activity. Cannot initiate or approve agreements. |
+| `researcher` | hub | Browse permitted catalog. Submit queries. View own results. No admin capabilities. |
+| `station_admin` | station | Accept/reject DSP agreements. Configure station access policy (asset/operation registry). Manage station operators. Register/deregister on discovery service. |
+| `station_operator` | station | Monitor station health, transfers, decision logs. Read-only on agreements and policy. |
+| `org_admin` | organization | Manage users and role assignments across all instances in the org. Cannot override station-level or hub-level policy decisions. |
+
+#### Cross-instance administration via organization
+
+A user with `org_admin` role can manage roles on any instance their organization operates. This is how a single hospital IT admin manages both their data station and their processing hub without needing separate accounts:
+
+```mermaid
+sequenceDiagram
+    participant OA as Org admin (Hospital A)
+    participant ORG as Org identity (Nuts)
+    participant SA as Station A (Hospital A)
+    participant HA as Hub A (Hospital A)
+
+    Note over OA,ORG: Org admin authenticated via org IdP<br/>org_admin role on organization level
+    OA->>SA: grant station_admin to colleague X<br/>(org_admin can assign roles on any org instance)
+    OA->>HA: grant hub_operator to colleague Y
+    OA->>HA: grant researcher to external collaborator Z
+    Note over OA: External collaborator Z belongs to<br/>a different org but is granted a role<br/>on Hub A specifically (instance-scoped)
+```
+
+#### External collaborators
+
+A researcher from Organization B can be granted a role on Hub A (operated by Organization A) without being a member of Organization A. This is handled by instance-scoped role assignment:
+
+- The researcher authenticates via their own organization's IdP (federated OIDC)
+- Hub A's `network_admin` or `org_admin` creates a role assignment with `user_id` pointing to the federated user and `instance_id` pointing to Hub A
+- The researcher appears in Hub A's user list with their home organization clearly labeled
+- The researcher's access is fully governed by Hub A's credential issuance policies and agreement mappings
+
+This supports the common scenario where a research consortium has members from multiple hospitals, all accessing data through a shared processing hub.
+
+#### How Nuts organizational identity connects to RBAC
+
+The `organization.nuts_org_credential_id` links the RBAC organization to its Nuts network identity. When a Nuts token arrives at a station, the station resolves the hub's DID to an organization, then looks up role assignments for users in that organization context:
+
+```
+Incoming request:
+  Nuts VP → hub DID: did:nuts:hubA
+  VC (PluginlakeAccessCredential) → user_id: researcher-Y, agreement_id: abc123
+
+Station resolves:
+  did:nuts:hubA → pluginlake_instance.id = hub-A
+  hub-A → organization_id = org-X
+  researcher-Y → role_assignment where instance_id = hub-A, role = researcher
+  → verified: researcher-Y has researcher role on hub-A
+  → proceed to ODRL enforcement with verified role context
+```
+
+The station does not need to query Hub A's IdP. It trusts the hub-signed VC for user identity (verified by VC signature against hub's DID document key) and checks its own role assignment table for authorization. Role assignments for external collaborators on a hub are replicated to connected stations as part of the DSP agreement metadata.
+
+#### Collaboration governance in the RBAC model
+
+A collaboration (e.g. a multi-hospital research consortium) is modeled as a separate entity with member organizations. The collaboration may operate its own hub instance (with its own Nuts DID) or designate one member's hub as the collaboration hub.
+
+The `coordinating_org_id` on the collaboration determines which organization's `org_admin` or `network_admin` can configure collaboration-wide policies. Member organizations retain `station_admin` authority over their own stations -- the collaboration coordinator can push agreements but station admins can only tighten constraints, never relax them.
+
+```mermaid
+graph TD
+    subgraph "Collaboration: PLUGIN consortium"
+        COORD[Coordinating org: DHD<br/>network_admin manages collab hub]
+        MEM1[Member: Hospital A<br/>station_admin on Station A]
+        MEM2[Member: Hospital B<br/>station_admin on Station B]
+        MEM3[Member: Hospital C<br/>station_admin on Station C]
+    end
+    subgraph "Collab Hub (operated by DHD)"
+        HUB[Hub instance<br/>DID: did:nuts:collab-hub]
+    end
+    COORD --> HUB
+    HUB --> SA[Station A]
+    HUB --> SB[Station B]
+    HUB --> SC[Station C]
+    MEM1 --> SA
+    MEM2 --> SB
+    MEM3 --> SC
+```
+
+
+## Enforcement: translating contracts to compute and data
+
+> This section describes the enforcement architecture at a high level. The detailed specification of query safety, filter validation, algorithm approval, and container sandboxing is deferred to **ADR-008: Contract-to-compute mapping and query safety**.
+
+### The translation problem
+
+An ODRL permission says "you may aggregate omop_condition for scientific research." The station must translate this abstract statement into a concrete DuckLake query or Dagster job execution with the correct constraints applied.
+
+```mermaid
+graph TD
+    REQ[Request + VC arrives] --> VERIFY[Verify VC: signature + issuer trust]
+    VERIFY --> AGREE[Check: VC references active agreement?]
+    AGREE --> EVAL[Evaluate ODRL claims against request]
+    EVAL --> MAP[Map ODRL target → local DuckLake table/asset]
+    MAP --> CONSTRAIN[Apply constraints: columns, rows, privacy thresholds]
+    CONSTRAIN --> TYPE{Operation type?}
+    TYPE -->|query/aggregate| SQL[Build constrained SQL → DuckLake]
+    TYPE -->|compute| DAG[Trigger Dagster job with constraints]
+    SQL --> PRIVACY[Post-execution: privacy validation]
+    DAG --> PRIVACY
+    PRIVACY -->|pass| RESULT[Return result]
+    PRIVACY -->|fail| SUPPRESS[Suppress result, log reason]
+```
+
+### Station asset registry
+
+Each station maintains a local registry that maps ODRL target URNs to its concrete local assets. This is station-specific because different hospitals may use different schemas, table names, or asset configurations for the same logical dataset.
+
+```yaml
+# Station-local config: station_assets.yaml
+assets:
+  "urn:pluginlake:dataset:omop_condition":
+    dagster_asset_key: ["omop", "condition_occurrence"]
+    ducklake_schema: "omop"
+    ducklake_table: "condition_occurrence"
+    available_columns:
+      - condition_concept_id
+      - condition_start_date
+      - condition_end_date
+      - condition_type_concept_id
+      - visit_occurrence_id
+    sensitive_columns:
+      - person_id    # never exposed externally regardless of VC claims
+    external: true   # visible in DSP catalog
+
+  "urn:pluginlake:dataset:omop_drug_exposure":
+    dagster_asset_key: ["omop", "drug_exposure"]
+    ducklake_schema: "omop"
+    ducklake_table: "drug_exposure"
+    available_columns:
+      - drug_concept_id
+      - drug_exposure_start_date
+      - drug_exposure_end_date
+      - quantity
+    sensitive_columns:
+      - person_id
+    external: true
+
+  "urn:pluginlake:dataset:omop_person":
+    dagster_asset_key: ["omop", "person"]
+    ducklake_schema: "omop"
+    ducklake_table: "person"
+    external: false  # never exposed in DSP catalog
+```
+
+### Station operation registry
+
+Operations define what compute patterns are available. Each operation maps to a concrete execution strategy.
+
+```yaml
+# Station-local config: station_operations.yaml
+operations:
+  "pluginlake:aggregate":
+    type: sql_template
+    description: "Grouped aggregation with count"
+    sql: "SELECT {columns}, COUNT(*) as n FROM {schema}.{table} {where} GROUP BY {columns}"
+    requires_group_by: true
+    min_group_size: 5  # k-anonymity: suppress groups smaller than this
+
+  "pluginlake:count":
+    type: sql_template
+    description: "Simple count"
+    sql: "SELECT COUNT(*) as n FROM {schema}.{table} {where}"
+
+  "pluginlake:query":
+    type: sql_constrained
+    description: "Column-restricted SELECT with row filters"
+    sql: "SELECT {columns} FROM {schema}.{table} {where} LIMIT {max_rows}"
+    max_rows_default: 10000
+
+  "pluginlake:federated_learning":
+    type: dagster_job
+    description: "Federated learning training round"
+    job_name: "fl_training_round"
+    container_image: "pluginlake/fl-worker:latest"
+    allowed_parameters:
+      - model_type
+      - epochs
+      - batch_size
+
+  "pluginlake:cohort_count":
+    type: dagster_asset
+    description: "Pre-defined cohort count asset"
+    asset_key: ["analytics", "cohort_count"]
+```
+
+### Constraint enforcement at query time
+
+When a request arrives, constraints from three sources are merged (most restrictive wins):
+
+```
+Agreement constraints (from DSP negotiation):
+  datasets: [omop_condition]
+  operations: [aggregate, count]
+  purpose: scientific-research
+
+VC constraints (from presented credential):
+  datasets: [omop_condition]
+  operations: [aggregate]
+  columns: [condition_concept_id, condition_start_date]
+
+Station-local restrictions (from config):
+  sensitive_columns: [person_id]  → always denied
+  min_k_anonymity: 5             → suppress small groups
+  max_result_rows: 50000         → hard limit
+
+Merged enforcement (most restrictive wins):
+  table: omop.condition_occurrence
+  columns: [condition_concept_id, condition_start_date]  (VC restricted)
+  person_id: DENIED (station restriction)
+  operation: aggregate
+  k-anonymity: 5 (station threshold)
+```
+
+The enforcement logic in Python:
+
+```python
+# src/pluginlake/authz/enforcement.py
+@dataclass
+class EnforcedQuery:
+    sql: str
+    parameters: dict
+    privacy_checks: list[PrivacyCheck]
+    audit_metadata: AuditRecord
+
+def enforce_request(
+    vc_claims: AccessCredentialClaims,
+    agreement: DSPAgreement,
+    request: DataRequest,
+    asset_registry: AssetRegistry,
+    operation_registry: OperationRegistry,
+    station_policy: StationPolicy,
+) -> EnforcedQuery | Denial:
+    """Translate a verified request into a constrained executable query."""
+
+    # 1. Resolve target to local asset
+    asset = asset_registry.resolve(request.target)
+    if not asset or not asset.external:
+        return Denial("dataset not available")
+
+    # 2. Check operation is allowed by agreement AND vc AND station
+    if request.operation not in agreement.permitted_operations:
+        return Denial("operation not in agreement scope")
+    if request.operation not in vc_claims.permitted_operations:
+        return Denial("operation not in credential scope")
+
+    # 3. Compute allowed columns (intersection, minus sensitive)
+    allowed_columns = (
+        set(asset.available_columns)
+        & set(vc_claims.permitted_columns or asset.available_columns)
+        - set(asset.sensitive_columns)
+    )
+
+    # 4. Build constrained query from operation template
+    # NOTE: request.filters uses a structured filter AST (not raw SQL).
+    # Only allowed columns/operators are accepted. Values are parameterized.
+    # Station row constraints are combined with AND before SQL generation.
+    # Full filter validation and query-to-compute mapping is specified in ADR-008.
+    operation = operation_registry.resolve(request.operation)
+    query = operation.build_sql(
+        schema=asset.ducklake_schema,
+        table=asset.ducklake_table,
+        columns=allowed_columns,
+        where=request.filters,  # structured AST, validated + parameterized
+        max_rows=station_policy.max_result_rows,
+    )
+
+    # 5. Attach privacy checks for post-execution validation
+    privacy_checks = [
+        KAnonymityCheck(min_k=station_policy.min_k_anonymity),
+        MaxCardinalityCheck(max_rows=station_policy.max_result_rows),
+    ]
+
+    return EnforcedQuery(sql=query, parameters={}, privacy_checks=privacy_checks, ...)
+```
+
+### Post-execution privacy validation
+
+After the query executes, results are validated before returning:
+
+```python
+# src/pluginlake/authz/privacy.py
+def validate_result(
+    result: pl.DataFrame,
+    privacy_checks: list[PrivacyCheck],
+) -> pl.DataFrame | Denial:
+    """Validate query results against privacy constraints."""
+    for check in privacy_checks:
+        result = check.apply(result)
+        if result is None:
+            return Denial(f"privacy check failed: {check.description}")
+    return result
+
+class KAnonymityCheck(PrivacyCheck):
+    """Suppress groups with fewer than k records."""
+    min_k: int = 5
+
+    def apply(self, df: pl.DataFrame) -> pl.DataFrame | None:
+        if "n" in df.columns:
+            return df.filter(pl.col("n") >= self.min_k)
+        return df
+```
+
+### Docker containers for custom compute
+
+For operations that require custom compute (federated learning, complex analytics), the credential grants access to specific Dagster jobs that run in isolated Docker containers:
+
+```
+VC says: action = "pluginlake:federated_learning"
+              target = "urn:pluginlake:dataset:omop_condition"
+
+Station resolves:
+  operation_registry["pluginlake:federated_learning"]
+    → type: dagster_job
+    → job_name: "fl_training_round"
+    → container_image: "pluginlake/fl-worker:latest"
+
+Station executes:
+  POST /api/assets/fl_training_round/materialize
+    with config: {
+      dataset: "omop.condition_occurrence",
+      columns: [allowed columns only],
+      parameters: [from request, validated against allowed_parameters]
+    }
+  → Dagster launches Docker container with constrained access
+  → Container can only read the columns/rows it was given
+  → Result returned via transfer process
+```
+
+The Docker container does not have direct DuckLake access — it receives a pre-filtered dataset as input. This ensures the container cannot read data beyond what the credential grants.
+
+### How the DSP catalog maps to the asset registry
+
+The DSP catalog endpoint (`GET /dsp/catalog`) is automatically generated from the station's asset registry. Only assets with `external: true` appear in the catalog:
+
+```python
+# src/pluginlake/dsp/routes.py
+@router.get("/dsp/catalog")
+async def get_catalog(registry: AssetRegistry = Depends(get_asset_registry)):
+    datasets = []
+    for urn, asset in registry.items():
+        if asset.external:
+            datasets.append({
+                "@type": "dcat:Dataset",
+                "@id": urn,
+                "dct:title": asset.ducklake_table,
+                "odrl:hasPolicy": build_catalog_offer(asset),
+            })
+    return {"@type": "dcat:Catalog", "dcat:dataset": datasets}
+```
+
+This ensures the catalog always reflects what the station is actually willing to share. If a station admin sets `external: false` on a dataset, it disappears from the catalog immediately.
+
+### Tooling decisions
+
+| Component | Tool | Rationale |
+|---|---|---|
+| ODRL profile evaluation | **Build: ~300 lines Python** | No production-grade Python library exists. `pyodre` (2 stars, dormant) is unsuitable. Our constrained profile is small enough to evaluate directly. |
+| VC signature verification | **`PyJWT` + `cryptography`** | Production-grade, well-maintained. Verify JWT-based VCs. For JSON-LD Data Integrity proofs, use `pyld` + `cryptography`. |
+| JSON-LD processing | **Pydantic (primary) + `pyld` (optional)** | Pydantic handles compacted JSON-LD directly. `pyld` added later if external connectors send expanded form. |
+| Nuts node client | **Auto-generate from OpenAPI spec** | Nuts node exposes OpenAPI. Use `openapi-python-client` to generate typed Python client. |
+| DSP protocol implementation | **Build: Pydantic models + FastAPI routes** | No reusable Python DSP library exists. `edcpy` requires Java EDC backend. Build native implementation. |
+| Privacy checks (k-anonymity) | **Build: Polars-based** | Simple post-query validation. ~50 lines per check type. |
+| Policy storage | **Pydantic Settings + YAML** | Station-local config. No external policy engine needed. |
+
+---
+
+## Nuts constraints and design considerations
+
+For detailed Nuts integration constraints (one node per instance, Discovery Service, DPoP validation, FHIR credential model, `localParameters` limitations, scope granularity), see [ADR-006: Nuts Node Integration](adr-006-nuts-node-decentralized-auth.md#nuts-constraints-and-design-considerations).
+
+**Key principle for this ADR:** Nuts handles organizational membership only. Per-dataset access control is not achievable at the Nuts layer. Fine-grained per-user permissions belong in the PluginlakeAccessCredential (VC with ODRL profile), not in Nuts credentials.
+
+---
+
+## DSP constraints (Eclipse Dataspace Protocol 2025-1)
+
+### JSON-LD is mandatory
+
+All DSP messages use JSON-LD. External connectors (especially EDC-based) may send compacted or expanded representations. Pydantic handles compacted form natively; add `pyld` for expansion/normalization if needed for interop with external connectors.
+
+### Provider must push state callbacks
+
+Even with pull data transfer, the Transfer Process requires outbound HTTP callbacks from provider to consumer on state changes. Dagster sensors handle this, but sensor reliability determines callback reliability.
+
+### No negotiation timeout defined
+
+DSP specifies no timeout for negotiations. Pluginlake must define its own timeout policy.
+
+### Dagster materialization is not idempotent
+
+Consumer retries can trigger duplicate runs. The transfer state machine must check for in-progress runs before triggering new ones.
+
+---
+
+## Phased delivery
+
+The full architecture (DSP + Nuts + ODRL profile + VC-based credentials + enforcement registry + RBAC) is substantial. Delivery is phased to validate each layer before building the next.
+
+### Phase 1: Single-station DSP provider with Nuts identity
+
+**Goal:** One data station can receive DSP requests from one processing hub, authenticated via Nuts. Basic contract negotiation works end-to-end. Hub-side DSP client is NOT in scope (tested with manual/scripted requests).
+
+**Delivers:**
+- `src/pluginlake/dsp/` module: DSP provider routes on FastAPI (catalog, negotiation, transfer)
+- Nuts middleware for organizational identity verification (auto-generated client)
+- Contract negotiation state machine (Postgres `dsp` schema)
+- Transfer process state machine backed by Dagster
+- Pull transfer with scoped token
+- Station asset registry (YAML config: which assets are externally visible)
+- Single hub, single station, manually configured
+- Integration test client (simulates hub DSP consumer requests)
+
+**Does not include:** hub-side DSP client, per-user credentials, multi-hub, RBAC dashboard, ODRL evaluation, collaboration governance.
+
+### Phase 2: VC-based credentials and ODRL profile evaluation
+
+**Goal:** Per-user authorization at the station. Hub issues credentials, station verifies and enforces.
+
+**Delivers:**
+- `src/pluginlake/authz/` module: ODRL profile evaluator, VC verification, enforcement layer
+- PluginlakeAccessCredential schema definition (ADR-008)
+- Hub issues VCs to researchers (signed by hub DID)
+- Station verifies VC at request time + cross-checks against active agreement
+- Station operation registry (YAML: maps actions to SQL templates / Dagster jobs)
+- Constraint enforcement (column filtering, row limits)
+- Post-execution privacy checks (k-anonymity)
+- Hub signing key distribution (via Nuts DID document)
+- Multi-hub topology tested
+
+### Phase 3: UI, governance, and collaboration
+
+**Goal:** Production-ready multi-organization network with operator dashboards and collaboration support.
+
+**Delivers:**
+- Hub UI (Streamlit `central`): credential issuance, user management, agreement monitoring
+- Station UI (Streamlit `datastation`): access control dashboard, agreement approval, restrictions config
+- RBAC entity model (roles, assignments, organizations, collaborations)
+- Governance models (data holder governed, collaboration governed, hybrid)
+- Decision logging and audit trail
+- Credential revocation (StatusList2021)
+- Collaboration coordinator workflow
+
+---
+
+## Consequences
+
+- pluginlake gains a DSP-compliant external surface aligned with the Health-RI data station specification and EHDS requirements
+- The processing hub specification (Health-RI §4.4, currently undefined) will be informed by this ADR's credential model and enforcement architecture
+- Every station runs two sidecars: Nuts node and Dagster code server. OPA is not required — enforcement is built into the pluginlake `authz` module using the ODRL profile evaluator.
+- The pluginlake ODRL profile (credential schema + actions + constraint types) is the highest priority deliverable. Without it, stations from different organizations cannot interoperate.
+- Hub signing key distribution must be resolved (options: key in Nuts DID document, key exchanged during DSP negotiation, key published via discovery registration parameters)
+- Station asset registry and operation registry must be defined per station (station-local YAML config)
+- Collaboration hubs need a governance decision on organizational identity before deployment
+- ODRL policies are evaluated against a constrained profile (Level 2) — not full ODRL. Profile extensibility is planned for future phases.
+- A new `src/pluginlake/authz/` module and `src/pluginlake/dsp/` module are required
+- The Streamlit UI gets new pages: credential management (central) and access control (datastation)
+
+---
+
+## Design risks by severity
+
+| Risk | Severity | Blocker? |
+|---|---|---|
+| ODRL profile not standardized → stations incompatible | High | Yes, must define before multi-org deployment |
+| Hub signing key distribution mechanism undefined | Medium | Must resolve before implementation |
+| Custom ODRL evaluator correctness (no reference impl to test against) | Medium | Mitigate with comprehensive test suite + DSP TCK |
+| Collaboration hub credential issuance → governance gap | Medium | Must resolve per collaboration |
+| No existing Bolt for research data exchange | Medium | No, ship as default policy file |
+| Sensor reliability for outbound DSP callbacks | Medium | No, mitigatable with retry tracking |
+| Nuts node per station requires outbound network | Medium | Verify per hospital firewall policy |
+| No prior Nuts + DSP + ODRL implementation as reference | Medium | No, budget extra integration testing time |
+| Credential re-issuance cost for permission changes | Medium | Mitigate with short-lived VCs + automated issuance |
+| DPoP validation adds latency per request | Low | No, Nuts convenience API handles it |
+| Dagster materialization not idempotent | Low | No, mitigatable with idempotency check |
+| SUSPENDED state not supported in v1 | Low | No, document as known gap |
+
+---
+
+## Open questions
+
+### Must resolve before implementation
+
+1. **Pluginlake ODRL profile specification** -- define the exact actions (`pluginlake:aggregate`, `pluginlake:query`, `pluginlake:count`, `pluginlake:compute`), constraint types (`purpose`, `dateTime`, `maxCardinality`, `columns`), and asset URN scheme (`urn:pluginlake:dataset:{name}`).
+2. **PluginlakeAccessCredential schema** -- the VC type, required fields, issuer rules, how ODRL permissions are embedded. Candidate for ADR-008.
+3. **Hub signing key distribution** -- how stations learn to trust hub signing keys. Likely resolved by: hub's DID document contains the signing key, station resolves DID via Nuts network.
+4. **Collaboration hub credential issuance** -- governance decision per collaboration.
+
+### Deferred to ADR-008: Contract-to-compute mapping and query safety
+
+The following questions are in scope for ADR-008 (not resolved here):
+
+5. **Structured filter AST and query parameterization** -- requests must use a validated filter structure (not raw SQL). Define allowed operators, column references, and how values are parameterized to prevent injection/bypass.
+6. **Pre-approved algorithm and container registry** -- which Docker images, Dagster jobs, and query patterns are allowed. How new algorithms get reviewed and approved before they can be referenced in a contract.
+7. **Privacy validation for non-aggregate queries** -- k-anonymity checks only apply to grouped results. Define what privacy controls apply to raw row-level queries (cohort-size thresholds, output-shape validation, or disabling raw query by default for clinical data).
+8. **Station-side credential/role synchronization** -- whether stations maintain local role lookups (replicated from hub) or rely purely on the VC presented per-request. Define revocation semantics, freshness guarantees, and what happens when a VC references a user the station has never seen.
+9. **Collaboration governance and trust boundary separation** -- how collaboration auto-approval works without blurring Nuts (network membership) and pluginlake (fine-grained authorization). Likely: separate governance credential/config checked by pluginlake, not by the Nuts Bolt.
+10. **Techniques to limit destructive or data-exfiltrating operations** -- sandboxing, network isolation, output size limits, differential privacy budgets, and how to detect/prevent side-channel exfiltration from approved containers.
+
+### Can resolve during implementation
+
+11. **IdP topology for hubs** -- Keycloak vs federated hospital IdPs (SURFconext, Microsoft Entra ID). Can differ per hub initially.
+12. **ODRL profile extensions** -- additional actions and constraints can be added as needs emerge. Profile is versioned.
+13. **Discovery service definition** -- JSON service definition for pluginlake. Ship as default.
+14. **Negotiation timeout** -- operational decision.
+15. **Credential validity duration** -- balance between short-lived (frequent re-issuance, fine-grained revocation) and long-lived (less operational overhead). Start with 24-hour VCs, adjust based on operational experience.
+16. **Processing hub specification alignment** -- contribute pluginlake's model to Health-RI §4.4 as the specification matures.
+17. **Processing hub DSP client implementation (v2)** -- hub-side DSP consumer/client, including catalog browsing, negotiation initiation, transfer request, and result retrieval.
+
+## Appendix A: International standards and ontologies for data contracts
+
+> **Editorial note:** This appendix catalogues the international standards relevant to pluginlake's authorization and contract architecture. It is reference material to inform vocabulary and schema design decisions.
+
+When designing an enterprise-grade data space — especially in a highly regulated landscape like the European Health Data Space (EHDS) — you should avoid inventing custom schemas. Several mature international standards and ontologies govern data contracts and policies:
+
+### W3C ODRL 2.2 (Open Digital Rights Language)
+
+*The standard for usage control.*
+
+* **What it is:** The premier W3C standard ontology for expressing policies, permissions, prohibitions, and obligations.
+* **Why it matters here:** The **Eclipse Dataspace Protocol (DSP) natively utilizes ODRL** to model contract negotiations, contract offers, and contract agreements. In a dataspace, an ODRL Contract Agreement is the definitive technical "Data Contract." It defines exactly what a consumer is allowed to do with a dataset (e.g., `odrl:Permission` to read, under the `odrl:Constraint` of a valid permit). pluginlake uses a constrained ODRL profile (Level 2) for its PluginlakeAccessCredential.
+
+### W3C DPV (Data Privacy Vocabulary)
+
+*The standard for legal bases and purposes.*
+
+* **What it is:** A highly active, community-driven W3C ontology explicitly designed to provide machine-readable metadata about the processing of personal data, purposes, legal bases (like GDPR or DGA), and technical/organisational measures.
+* **Why it matters here:** DPV provides a native guide for integration with ODRL (`GUIDE-ODRL`). For the EHDS, DPV allows you to taxonomically declare the *exact legal purpose of data use* (e.g., `dpv:ScientificResearch` or `dpv:PublicHealthOversight`) within both the Nuts credential and the ODRL policy, ensuring semantic alignment across different European health authorities.
+
+### OASIS XACML (eXtensible Access Control Markup Language)
+
+*The standard for access architecture.*
+
+* **What it is:** An international standard that defines both an XML-based policy language and a strict architectural paradigm for Attribute-Based Access Control (ABAC).
+* **Why it matters here:** While XACML's XML language has been superseded in modern stacks by JSON and domain-specific languages, its **architectural concepts remain relevant**: the PEP (Policy Enforcement Point — the HTTPS gateway), the PDP (Policy Decision Point — the ODRL evaluator), and the PIP (Policy Information Point — the asset/operation registry). pluginlake's enforcement layer follows this structural pattern without XACML's verbosity.
+
+### The IDSA Information Model (International Data Spaces)
+
+* **What it is:** An RDFS/OWL ontology developed by the International Data Spaces Association. It builds a comprehensive semantic layer over data assets, participants, connectors, and usage contracts.
+* **Why it matters here:** It blends ODRL with specialized data space concepts, creating standard definitions for "Contract Agreements" that legally bind data transactions between multi-party connectors.
+
+### ODCS (Open Data Contract Specification)
+
+*The standard for data ops and mesh.*
+
+* **What it is:** A rapidly growing open-source community standard (found at `datacontract.com`) utilized heavily in modern data engineering and data mesh patterns.
+* **Why it matters here:** It is important to distinguish this from ODRL. While ODRL handles *legal compliance, permissions, and usage rights*, ODCS handles *operational mechanics* (schema validation, data quality thresholds, freshness SLAs, and column-level formatting).
+
+### How these standards compose in pluginlake
+
+For a comprehensive EHDS-aligned design, these standards fit together as a composable stack:
+
+1. **The Legal/Regulatory Layer:** Governed by **W3C DPV** to define valid health purposes and legal bases.
+2. **The Data Space Protocol Layer:** Governed by **W3C ODRL** via the Eclipse Dataspace Protocol to draft the formal multi-party Contract Agreement.
+3. **The Identity & Evidence Layer:** Governed by **W3C Verifiable Credentials** (via Nuts) to securely carry the DPV-aligned claims as cryptographic evidence.
+4. **The Enforcement Layer:** The pluginlake ODRL profile evaluator maps the incoming ODRL-negotiated constraints (from the VC) against station-local policy (asset + operation registry) and executes the constrained query.

--- a/docs/background/dsp-authorization.md
+++ b/docs/background/dsp-authorization.md
@@ -1537,7 +1537,7 @@ This ensures the catalog always reflects what the station is actually willing to
 
 ## Nuts constraints and design considerations
 
-For detailed Nuts integration constraints (one node per instance, Discovery Service, DPoP validation, FHIR credential model, `localParameters` limitations, scope granularity), see [ADR-006: Nuts Node Integration](adr-006-nuts-node-decentralized-auth.md#nuts-constraints-and-design-considerations).
+For detailed Nuts integration constraints (one node per instance, Discovery Service, DPoP validation, FHIR credential model, `localParameters` limitations, scope granularity), see [ADR-006: Nuts Node Integration](../decisions/adr-006-nuts-node-decentralized-auth.md#nuts-constraints-and-design-considerations).
 
 **Key principle for this ADR:** Nuts handles organizational membership only. Per-dataset access control is not achievable at the Nuts layer. Fine-grained per-user permissions belong in the PluginlakeAccessCredential (VC with ODRL profile), not in Nuts credentials.
 

--- a/docs/background/federated-infrastructure.md
+++ b/docs/background/federated-infrastructure.md
@@ -1,0 +1,916 @@
+# Federated Infrastructure Comparison
+
+This document evaluates federated infrastructure platforms relevant to pluginlake, a federated data lakehouse for Dutch healthcare.
+It covers architecture patterns, authentication, authorization, collaboration workflows, federated computation, and privacy features.
+Each platform is assessed for maturity, healthcare readiness, and regulatory alignment.
+
+The goal is to answer a practical question: does pluginlake need an external federated learning framework (such as vantage6) for federated computations, or can it achieve its goals with its current stack?
+
+pluginlake is a federated data lakehouse where each hospital runs its own data station.
+Stations exchange data and query each other without a central identity provider.
+The data layer is DuckDB/DuckLake, with OMOP CDM for clinical data modeling and FHIR ingestion managed by Dagster.
+A FastAPI gateway exposes query and data access endpoints.
+Authentication and authorization will be handled by a Nuts Node sidecar (W3C DIDs, Verifiable Credentials, OAuth2 token exchange), as documented in [ADR-006](../decisions/adr-006-nuts-node-decentralized-auth.md).
+
+## 1. Scope and method
+
+We evaluate three categories of infrastructure:
+
+1. Dutch healthcare infrastructure: Nuts Node, KIK-V (as a Nuts reference implementation).
+2. EU dataspace infrastructure: HealthData@EU Central Platform (EHDS2), EDC/iSHARE/Gaia-X.
+3. Federated learning platforms: Flower, vantage6, NVIDIA FLARE, PySyft, OpenFL, Brane, FedML, and others.
+
+| Criterion | What we assess |
+|---|---|
+| Architecture topology | Client-server, peer-to-peer, hybrid |
+| Authentication and authorization | How nodes prove identity and how access is enforced |
+| Collaboration model | How organizations form and manage partnerships |
+| Federated computation | What can be computed across nodes |
+| Privacy features | Differential privacy, secure aggregation, encryption |
+| Healthcare readiness | Compliance, audit trails, patient data handling |
+| Maturity | Release stability, production deployments, maintenance |
+
+Sources include official documentation, source code repositories, and the academic literature collected in [docs/papers/](../papers/).
+
+---
+
+## 2. Platform catalog
+
+### 2.1 Nuts Node
+
+[Nuts](https://nuts-node.readthedocs.io/en/v5.4/) is an open-source, decentralized identity and authorization infrastructure for Dutch healthcare.
+It provides the trust layer that pluginlake will use for inter-station authentication and authorization.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Peer-to-peer with bootstrap nodes. All nodes hold a full replica of the transaction DAG. |
+| **AuthN** | W3C DIDs (`did:nuts`) backed by PKIoverheid certificates. Node-to-node: gRPC with mTLS. User sessions: Verifiable Presentations (IRMA/Yivi, UZI). |
+| **AuthZ** | `NutsAuthorizationCredential` VCs grant per-patient, per-resource, per-purpose access. OAuth2 JWTs via the `/n2n` endpoint. |
+| **Collaboration** | Organizations discover each other via the DID registry. Collaboration is formalized through Bolt specifications (application-specific trust agreements). VCs exchanged privately. |
+| **Computation** | None. Nuts is a trust and identity layer. Computation happens in applications that use Nuts for auth. |
+| **Privacy** | Data stays at the station unless authorized. Access auditable (NEN 7513). Credentials distributed privately. |
+| **Healthcare** | Purpose-built for Dutch healthcare: NEN 7510/7512/7513, AVG/GDPR, Wegiz, Wabvpz. Production deployments across Dutch vendors. |
+| **Stack** | Go binary. REST API (OpenAPI 3.0) + gRPC. Docker sidecar (~200 MB). 256 MB RAM, 1 vCPU typical. GPLv3. |
+
+Nuts is the selected auth backbone for pluginlake (see [ADR-006](../decisions/adr-006-nuts-node-decentralized-auth.md)).
+It is not a computation platform; it complements federated learning frameworks by providing trust.
+
+#### How the Nuts network works
+
+Nuts is "decentralized" in the sense that no single party controls identity or access decisions, but it still forms a peer-to-peer network.
+
+**Network formation:**
+
+1. A new node connects to one or more bootstrap nodes (just regular peers) over gRPC with mTLS.
+2. The bootstrap node shares a copy of the network's transaction DAG (append-only, signed).
+3. After initial sync, the new node discovers other peers from the transaction data and connects directly. The bootstrap node is not special after this point.
+4. All nodes hold a full replica of the DAG and validate every transaction independently.
+
+There is no central server, registry, or single point of failure. The network is permissioned (all nodes must present a certificate from an agreed-upon CA, e.g. PKIoverheid in production).
+
+**Identity layer (DIDs + Verifiable Credentials):**
+
+- Each organization gets a `did:nuts:...` identifier (public/private key pair).
+- The DID becomes meaningful when a trusted party issues a `NutsOrganizationCredential` linking the DID to a real organization name and identifiers.
+- DID Documents are propagated through the network automatically.
+
+**Authentication flow:**
+
+1. A practitioner signs a contract ("I act on behalf of Hospital X") using a supported means: employee identity, IRMA/Yivi, or UZI card.
+2. This produces a Verifiable Presentation (cryptographic proof of identity + organization affiliation).
+3. The requesting station's Nuts node uses this VP to request an OAuth2 access token from the data-holding station's Nuts node (`/n2n` endpoint).
+4. The access token is a standard JWT that the data holder's API can validate.
+
+**Authorization flow:**
+
+1. The data holder issues a `NutsAuthorizationCredential` specifying: which patient, which resources, which requesting organization, and for what purpose.
+2. This credential is distributed privately over the authenticated node-to-node connection.
+3. When an access token is requested, the Nuts node checks the authorization credential before issuing. The API never sees raw credentials, only validated access tokens.
+
+| Concern | Handled by | Where it runs |
+|---|---|---|
+| DID management, key storage | Nuts Node | Sidecar container per station |
+| Credential issuance and verification | Nuts Node | Sidecar container per station |
+| User authentication (contract signing) | Nuts Node `/public` API + browser | Nuts Node + user's browser/IRMA app |
+| OAuth2 access token issuance | Nuts Node `/n2n` API | Node-to-node, mTLS |
+| Access token validation | FastAPI middleware | pluginlake API gateway |
+| Resource-level access control | FastAPI middleware | pluginlake API gateway |
+| Audit logging | FastAPI middleware + Nuts Node | Both |
+
+#### Bolt specifications and collaboration enforcement
+
+A Bolt is a functional and technical specification that translates a use case into concrete access rules.
+It is a protocol definition, not a collaboration registry: it describes what interactions are possible, not who is currently interacting.
+
+pluginlake defines one Bolt (`pluginlake-federation`) that describes:
+
+- The allowed `purposeOfUse` values (e.g. `pluginlake-query-dispatch`, `pluginlake-data-serve`).
+- The credential types required per purpose.
+- The API endpoints each purpose may call.
+- The data scopes available per purpose.
+
+Every station runs the same Bolt specification. Actual collaborations are represented as individual `NutsAuthorizationCredential` VCs issued by the data-holding station to the requesting station. Each credential encodes:
+
+- The requesting organization's DID.
+- The data scope (tables, cohort filter, date range).
+- The purpose of use (must match a value defined in the Bolt).
+- The validity period.
+
+| Layer | What it contains | Scope | Visibility |
+|---|---|---|---|
+| Bolt specification | Protocol rules, allowed purposes, required credentials | Network-wide | Public (same for all stations) |
+| `NutsAuthorizationCredential` | One collaboration between specific parties | Bilateral | Private (only issuer + subject) |
+
+#### Decentralized contract storage
+
+Collaboration credentials are stored on the Nuts network's transaction DAG:
+
+- The DAG is an append-only, cryptographically signed, distributed ledger replicated across all Nuts Nodes.
+- When a station issues a `NutsAuthorizationCredential`, it is written as a signed transaction.
+- The credential is distributed privately using Nuts' `pal` (Participants Access List) header, encrypted with the public keys of only the intended recipients.
+- Each station's Nuts Node maintains a local copy of only the credentials it is allowed to see.
+- Revocation also happens on the DAG: the issuer publishes a revocation transaction.
+
+Every station that is party to a collaboration has an independent, locally verifiable copy of the contract. No station depends on a central server to discover or validate its agreements.
+
+#### Security model: compromised nodes
+
+1. **Credentials cannot be forged.** Each VC is signed by the issuing station's DID private key. A compromised requesting node cannot fabricate a credential.
+2. **The DAG is append-only.** A compromised node cannot rewrite or delete existing transactions. Authorization credentials are issued by the data holder (not the requester).
+3. **Credentials can be revoked.** Issuing stations can revoke all VCs granted to a compromised station's DID. Existing tokens expire within their short TTL.
+4. **The private key is the blast radius.** If a station's own key is compromised, the attacker can impersonate that station. Other stations' keys are unaffected. The response is to rotate the DID's key material.
+5. **Short-lived access tokens limit exposure.** Nuts OAuth2 tokens have a configurable TTL (typically minutes).
+
+### 2.2 KIK-V
+
+[KIK-V](https://kik-v.nl/) is a Dutch program for nursing care data exchange, built on the Nuts network.
+The [technical specifications (v1.1.3)](https://kik-v-publicatieplatform.nl/documentatie/nuts-technischespecificaties/1.1.3) describe the full protocol.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Decentralized via Nuts. Each care organization runs its own Nuts node. |
+| **AuthN/AuthZ** | Inherits Nuts DIDs + VCs. PKIoverheid certificates. mTLS transport. |
+| **Data model** | OWL2/RDF ontologies. SPARQL 1.1 queries. SHACL parameter validation. |
+| **Messaging** | Asynchronous DIDComm over Nuts. Point-to-point, no intermediary. |
+| **Governance** | Structured matching process: data consumers and providers agree on queries through the KIK-V management organization. Validated queries are issued as `ValidatedQueryCredential` VCs. |
+| **Maturity** | Operational. [Afsprakenset v3.1.0](https://kik-v-publicatieplatform.nl/afsprakenset/3.1.0). Multiple exchange profiles published for IGJ, NZa, VWS. |
+
+KIK-V validates the Nuts approach for healthcare data exchange. Key patterns for pluginlake:
+
+| KIK-V pattern | pluginlake equivalent |
+|---|---|
+| Validated query as a VC | `PluginlakeQueryCredential` VCs per collaboration |
+| SPARQL embedded in credential | SQL query templates or query scopes in credentials |
+| SHACL parameter shapes | JSON Schema / Pydantic parameter constraints |
+| DIDComm messaging | FastAPI endpoints secured by Nuts OAuth2 |
+| Exchange profiles | Bolt specifications for federation agreements |
+| Governance-approved queries only | Graduated computation validation levels (see section 3.4) |
+
+### 2.3 HealthData@EU Central Platform (EHDS2)
+
+The [HealthData@EU Central Platform](https://acceptance.data.health.europa.eu/) implements the European Health Data Space for secondary use.
+[Release 3](https://op.europa.eu/en/publication-detail/-/publication/52fe4b0e-0ac4-11f0-b1a3-01aa75ed71a1) was [open-sourced](https://ec.europa.eu/digital-building-blocks/sites/spaces/DIGITAL/blog/2025/03/27/887383631/EHDS2+Central+Platform+3+goes+open+source+with+enhanced+eDelivery+integration) in March 2025 under EUPL 1.2.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Four-corner model via eDelivery AS4 (Domibus). National access points mediate between requesters/providers. |
+| **AuthN/AuthZ** | API keys internally. eDelivery certificates cross-border. Data permits from national HDABs. |
+| **Computation** | Secure Processing Environments mandated by EHDS Art. 50, not yet implemented (expected Release 5-6). |
+| **Stack** | Java 17+ (Spring Boot), MongoDB, Apache Camel, Domibus. EUPL 1.2. |
+| **Maturity** | Release 3 of 6. Full operational readiness (including SPEs) targeted for Release 6 (~2028-2029). |
+
+HealthData@EU operates at a different layer: EU cross-border routing and permits.
+pluginlake operates at the operational level within Dutch healthcare.
+The two are complementary; pluginlake could expose datasets through a national access point adapter.
+
+### 2.4 European dataspace protocols (EDC, iSHARE, Gaia-X)
+
+| Protocol | Model | Healthcare fit | Why not chosen |
+|---|---|---|---|
+| **EDC / Tractus-X** | Control Plane + Data Plane, `did:web`, ODRL policies. Java/Kotlin, 5+ services per participant. Apache 2.0. | Low. No patient-level authz, no UZI/IRMA, no PKIoverheid. Automotive focus. | High integration effort, no healthcare features. |
+| **iSHARE** | Dutch trust framework (logistics origin). OAuth2 M2M, central Participant Registry. | Low. No patient-level authz, no DID/VC model. Semi-centralized registry dependency. | Central registry conflicts with decentralized architecture. |
+| **Gaia-X** | Governance overlay (specs, compliance labels). Not deployable software. | Neutral. Does not prescribe or prevent healthcare features. | Not an implementation. Complementary as a compliance label. |
+
+Nuts is preferred over all three for pluginlake: purpose-built for Dutch healthcare, patient-level authorization, single sidecar deployment, active Dutch healthcare adoption.
+All three share W3C DID/VC primitives and can interoperate with Nuts in the future.
+
+### 2.5 Flower
+
+[Flower](https://flower.ai/) (v1.x/2.x) is an open-source, framework-agnostic federated learning platform.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Client-server. SuperLink coordinates SuperNodes. |
+| **AuthN/AuthZ** | EC key-based node auth. No RBAC. |
+| **Collaboration** | None. Assumes a single operator. Cross-org trust must be built externally. |
+| **Computation** | FedAvg, FedSGD, custom strategies. PyTorch, TensorFlow, JAX, scikit-learn. Simulation mode. |
+| **Privacy** | Differential privacy (Opacus/TF Privacy). Secure aggregation (SecAgg/SecAgg+). |
+| **Healthcare** | No healthcare features. No audit trail. Needs wrapping for healthcare use. |
+| **Stack** | Python. gRPC. Docker or pip. Apache 2.0. Flower Cloud (commercial managed). |
+
+pluginml already uses Flower for ML aggregation and training.
+Flower does not include built-in trust establishment, access control, or audit logging, so it requires a complementary infrastructure layer for healthcare deployments.
+
+### 2.6 vantage6
+
+[vantage6](https://docs.vantage6.ai/) (v4.x) is a federated analysis infrastructure by [IKNL](https://iknl.nl/), designed for healthcare.
+
+pluginlake currently uses vantage6 in production via the `pluginml` module, and at the current federation size it remains the recommended orchestrator for federated ML workloads.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Client-server. Central server coordinates nodes (Docker containers). |
+| **AuthN** | Username/password + 2FA. API keys. TLS. |
+| **AuthZ** | RBAC (root, admin, researcher, node). Algorithm whitelisting. Per-org permissions. |
+| **Collaboration** | First-class concept. Organizations registered on server. Tasks scoped to collaborations. |
+| **Computation** | Algorithm containers (any Docker image). Aggregation on server. Subtask chaining. MPC support. |
+| **Privacy** | E2E RSA encryption. Algorithm whitelisting. Data stays at node. SSH tunneling for MPC. |
+| **Healthcare** | Designed for healthcare. GDPR-aligned. Used in Dutch oncology (IKNL network). Active in Health-RI. |
+| **Stack** | Python (Flask). PostgreSQL/SQLite. Docker. RabbitMQ. SocketIO. Apache 2.0. |
+
+Operational experience in the PLUGIN project surfaced architectural trade-offs documented in the [production readiness assessment](../papers/production-readiness-assessment.md).
+At scale beyond ~20 nodes, the following trade-offs become relevant:
+
+- Hub-and-spoke: all traffic through a single SocketIO connection per collaboration, saturating before hardware is utilized.
+- No control/data plane separation: status polling and large payloads share the same JSON + base64 channel.
+- Shared encryption keys per organization with no forward secrecy.
+- Central server sees all task metadata across collaborations.
+- No per-request auth for node-to-node communication (VPN tunnels instead of transactional auth).
+
+These are trade-offs inherent to vantage6's hub-and-spoke design, which prioritizes simplicity and ease of deployment for small-to-medium federations. For larger federations or use cases requiring per-request cryptographic auth, a complementary trust layer (such as Nuts) fills the gap.
+
+### 2.7 NVIDIA FLARE
+
+[NVIDIA FLARE](https://nvflare.readthedocs.io/) (v2.x) is NVIDIA's enterprise FL framework.
+
+| Aspect | Details |
+|---|---|
+| **Topology** | Client-server. FL server + FL clients (sites). |
+| **AuthN/AuthZ** | PKI with project CA, mTLS. Per-site authorization policies. Admin roles. |
+| **Computation** | FedAvg, FedProx, FedOpt, SCAFFOLD. PyTorch, TensorFlow, XGBoost. Controller/Executor API. |
+| **Privacy** | DP filters, HE (TenSEAL), TEEs (NVIDIA Confidential Computing). Per-site privacy filters. |
+| **Healthcare** | Medical imaging (Clara ecosystem). No NEN/GDPR tooling. GPU-oriented. |
+| **Stack** | Python. gRPC. NVIDIA NGC images. Apache 2.0. NVIDIA AI Enterprise (commercial support). |
+
+Strong security and privacy primitives, but assumes GPU infrastructure.
+Over-engineered for pluginlake's tabular/SQL workloads.
+
+### 2.8 Other platforms
+
+| Platform | Status | Why not selected |
+|---|---|---|
+| **PySyft** (OpenMined) | v0.9.x, declining maintenance | Manual code review model is appealing but API breaks across versions. OpenMined pivoted. High risk. |
+| **OpenFL** (Intel) | Stable, niche | Medical imaging focus (FeTS). No RBAC. Limited value for SQL/aggregate workloads. |
+| **Brane** (UvA) | Archived Oct 2025 | Excellent policy reasoner concept. Rust/K8s. Dead codebase, design patterns worth studying. |
+| **FedML / TensorOpera** | OSS abandoned Oct 2023 | Pivoted to proprietary SaaS. Incompatible with data sovereignty. |
+| **Substra** (Owkin) | Active, v0.47+ | Strong privacy model. Requires Kubernetes per org. Worth revisiting if pluginlake moves to K8s. |
+| **FATE** (WeBank) | Maintenance mode | Rich MPC/HE. Declining activity. Chinese ecosystem, limited EU healthcare presence. |
+| **TensorFlow Federated** | Active | TF-only. Simulation-only, no production deployment infra. |
+| **PaddleFL** / **IBM FL** | Low activity / proprietary | Tight ecosystem coupling. No EU healthcare presence. |
+
+---
+
+## 3. Comparison by functional concern
+
+### 3.1 Network topology and collaboration
+
+#### Topology
+
+| Platform | Topology | Central component | Fails if central goes down |
+|---|---|---|---|
+| Nuts Node | Peer-to-peer | None (bootstrap nodes not privileged) | No |
+| KIK-V | Peer-to-peer (via Nuts) | None | No |
+| HealthData@EU | Four-corner (eDelivery) | EU routing infrastructure | Yes |
+| Flower | Client-server | SuperLink | Yes |
+| vantage6 | Client-server | Central server | Yes |
+| NVIDIA FLARE | Client-server | FL server | Yes |
+| PySyft | Datasite (per-owner) | None (each Datasite centralized) | Per-Datasite |
+| OpenFL | Client-server | Aggregator | Yes |
+| Brane | Hybrid | Orchestrator | Yes |
+
+#### Collaboration models
+
+| Platform | How collaborations are formed | Collaboration granularity |
+|---|---|---|
+| Nuts / KIK-V | Bolt specifications + VC-based trust agreements. Governed matching process (KIK-V). Organizations discover each other via DID registry. | Per-query, per-purpose. Credentials scoped and revocable. |
+| HealthData@EU | Formal permit application to national HDAB. Routing configured by the platform. | Per-dataset, per-use-case. Permit-scoped. |
+| EDC / Tractus-X | Contract negotiation (DSP). ODRL usage policies. Bilateral agreements. | Per-contract, per-asset. |
+| Flower | No collaboration model. Single operator assumed. | N/A |
+| vantage6 | Organizations registered on central server. Explicit collaboration groups. Tasks scoped to collaborations. | Per-collaboration, per-algorithm. |
+| NVIDIA FLARE | Project-based. Admin provisions CA and distributes startup kits. Per-site policies. | Per-project. |
+| PySyft | Data scientists discover Datasites. Trust via code review. | Per-computation (manual). |
+| OpenFL | Plan-based (YAML). All collaborators agree on plan before training. | Per-experiment. |
+
+#### Communication patterns
+
+| Platform | Transport | Serialization | Direct node-to-node |
+|---|---|---|---|
+| Nuts | gRPC (mTLS) + REST (HTTPS) | JSON-LD, JWS | Yes (peer-to-peer) |
+| KIK-V | DIDComm over HTTPS/mTLS | JSON-LD/Turtle, SPARQL JSON, JWS | Yes (via Nuts) |
+| HealthData@EU | AS4/HTTPS (Domibus) | XML (OASIS AS4) | Via access points |
+| Flower | gRPC | Protocol Buffers | No (via SuperLink) |
+| vantage6 | SocketIO + REST | JSON + base64 | SSH tunnel only (MPC) |
+| NVIDIA FLARE | gRPC | Protocol Buffers | No (via FL server) |
+
+### 3.2 Governance and trust
+
+| Platform | Trust model | Who controls access | Policy language | Revocation |
+|---|---|---|---|---|
+| Nuts | DIDs + VCs, PKIoverheid CA | Each station enforces its own policies | Bolt specifications | Credential revocation via Nuts network |
+| KIK-V | Nuts credentials + governance body | KIK-V management org issues query credentials | Matching process + SHACL shapes | Credential revocation (10s leash) |
+| HealthData@EU | eDelivery certs, national HDABs | National HDABs issue permits | EHDS Art. 33-37 | Permit expiry/revocation |
+| Flower | EC keys | Key holder (single operator) | None | Key rotation |
+| vantage6 | Username/2FA, API keys | Central server admin | Server RBAC config | Account/key revocation on server |
+| NVIDIA FLARE | PKI with project CA | Project admin + per-site policies | JSON policy files | Certificate revocation |
+| PySyft | User accounts, code review | Data owner (manual) | Human judgment | Account removal |
+
+KIK-V's governance model is instructive for pluginlake: queries are predefined (not ad-hoc), parameters are constrained via schemas, providers can reject even valid credentials, and credentials are revocable. This "governance-by-credential" pattern applies directly to pluginlake, with SQL/containers instead of SPARQL.
+
+### 3.3 Authentication and authorization
+
+| Platform | Node/site authN | User authN | AuthZ model | AuthZ granularity | NEN 7512 compliance |
+|---|---|---|---|---|---|
+| Nuts | mTLS (PKIoverheid) | VPs (IRMA/Yivi, UZI) | Verifiable Credentials | Per-patient, per-resource, per-purpose | Yes (designed for) |
+| HealthData@EU | eDelivery certs | API keys (internal) | Data permits (HDABs) | Per-dataset, per-use-case | Via eDelivery |
+| EDC | `did:web` + mTLS | Connector admin | ODRL policies | Per-contract, per-asset | No |
+| iSHARE | PKI certificates | OAuth2 M2M | Delegation evidence | Per-delegation chain | Partial |
+| Flower | EC keys | None | None (key = access) | Binary | No |
+| vantage6 | API keys / TLS | Username + 2FA | RBAC + whitelisting | Per-collaboration, per-algorithm | No (API keys insufficient) |
+| NVIDIA FLARE | mTLS (project CA) | Admin CLI with roles | Per-site policies | Per-operation, per-site | Partial (PKI, not PKIoverheid) |
+| PySyft | None | Email/password | Manual code approval | Per-computation | No |
+| OpenFL | mTLS (shared CA) | None | None (cert = access) | Binary | Partial |
+
+Only Nuts natively meets NEN 7512 requirements for trusted electronic communication in healthcare.
+Any FL platform used in Dutch healthcare would need Nuts (or equivalent) as the auth layer.
+
+### 3.4 Compute orchestration
+
+#### Task dispatch
+
+| Platform | How tasks are dispatched | Who sees task metadata | Scalability model |
+|---|---|---|---|
+| KIK-V | Direct DIDComm messages between stations | Only participating parties | Linear (P2P) |
+| vantage6 | Central server dispatches to nodes via SocketIO | Central server + participants | Scale the server (bottleneck) |
+| Flower | SuperLink dispatches to SuperNodes via gRPC | SuperLink + participants | Scale the SuperLink |
+| NVIDIA FLARE | FL server dispatches via gRPC | FL server + sites | Scale the FL server |
+
+#### Algorithm and container management
+
+All FL platforms use containers (Docker images) for algorithm execution.
+The key difference is how trust in those containers is established.
+
+| Mechanism | What it proves | Strictness | Tooling |
+|---|---|---|---|
+| Image digest pinning (SHA256) | Exact binary approved | Highest | Docker/OCI native |
+| Container signing (cosign/sigstore) | Trusted party vouches for image | High | [cosign](https://docs.sigstore.dev/cosign/signing/overview/), [Notary v2](https://notaryproject.dev/) |
+| SBOM attestation (CycloneDX/SPDX) | Exact dependencies known | Medium-high | [syft](https://github.com/anchore/syft), [grype](https://github.com/anchore/grype) |
+| Reproducible builds | Same source = same digest | Highest (when feasible) | [apko](https://github.com/chainguard-dev/apko), deterministic Dockerfiles |
+| Source provenance (SLSA) | Built from this commit by this CI | Medium-high | [SLSA](https://slsa.dev/), GitHub Actions attestations |
+| Algorithm registry with review | Governance body approved this version | Variable | vantage6 algorithm store, custom |
+
+Graduated validation levels for pluginlake:
+
+| Level | Name | Validated | Use case |
+|---|---|---|---|
+| 0 | Sandbox | Nothing; synthetic data only | Prototyping, hackathons |
+| 1 | Registry-only | Image from approved registry | Exploration with known collaborators |
+| 2 | Signed | cosign signature + SBOM scanned | Standard research collaborations |
+| 3 | Pinned + attested | Digest pinned in credential, SLSA provenance | Production analytics, regulatory reporting |
+| 4 | KIK-V equivalent | Exact computation in VC, parameters schema-constrained, every execution logged | National quality indicators |
+
+vantage6 implements levels 1-2 via tag-based whitelisting, which is appropriate for trusted collaborations. Digest pinning and signing (level 3) can be layered on top for higher-assurance deployments.
+
+#### Aggregation patterns
+
+| Pattern | Platforms | Privacy | Complexity |
+|---|---|---|---|
+| Central aggregation | vantage6, Flower, FLARE, OpenFL | Aggregator sees all updates | Low |
+| Secure aggregation (SecAgg) | Flower (SecAgg+), FLARE (partial) | Individual updates hidden | Medium |
+| Homomorphic encryption | FLARE (TenSEAL) | Computation on encrypted data | High |
+| TEE-based | FLARE (NVIDIA CC) | Hardware-level isolation | High (requires NVIDIA hardware) |
+| No aggregation (query results only) | KIK-V, pluginlake planned | Each station returns independent result | Lowest |
+
+### 3.5 Privacy and security
+
+| Platform | DP | SecAgg | Encryption | HE/MPC | TEE | Data stays at source |
+|---|---|---|---|---|---|---|
+| Nuts | N/A | N/A | TLS + encrypted VCs | No | No | Yes (by design) |
+| HealthData@EU | No | No | TLS + eDelivery signing | No | SPEs (future) | Yes (permit-scoped) |
+| Flower | Yes (Opacus) | Yes (SecAgg+) | TLS | No | No | Yes |
+| vantage6 | No | No | E2E RSA | Partial (SSH for MPC) | No | Yes |
+| NVIDIA FLARE | Yes (filters) | Yes | TLS | Yes (TenSEAL) | Yes (NVIDIA CC) | Yes |
+| PySyft | Partial | No | TLS | Partial (CrypTen) | No | Yes (code review) |
+| OpenFL | Yes (basic) | Planned | TLS | No | No | Yes |
+
+### 3.6 Regulatory compliance
+
+| Requirement | Nuts | vantage6 | Flower | NVIDIA FLARE | HealthData@EU |
+|---|---|---|---|---|---|
+| GDPR data minimization | ✅ data at source | ✅ results only | ⚠️ manual | ⚠️ manual | ✅ permit-scoped |
+| GDPR lawful basis tracking | ✅ VCs encode purpose | ⚠️ collaboration metadata | ❌ | ❌ | ✅ permits |
+| EHDS Art. 50 (SPEs) | N/A | ⚠️ Docker (partial) | ❌ | ⚠️ TEE | ⚠️ planned |
+| NEN 7510 (ISMS) | ✅ designed for | ⚠️ no guidance | ❌ | ❌ | ⚠️ EU-level |
+| NEN 7512 (trusted comm.) | ✅ PKIoverheid + mTLS | ⚠️ TLS + API keys | ❌ | ✅ PKI + mTLS | ⚠️ eDelivery |
+| NEN 7513 (access logging) | ✅ built in | ⚠️ task logging | ❌ | ⚠️ admin logging | ⚠️ planned |
+| Wegiz (electronic exchange) | ✅ designed for | N/A | N/A | N/A | N/A |
+| Wabvpz (patient rights) | ⚠️ access logging | ❌ | ❌ | ❌ | ⚠️ planned |
+
+Key gaps:
+
+1. **No FL platform addresses NEN 7510/7512/7513 natively.** Only Nuts is designed around these Dutch standards. Any FL platform needs Nuts (or equivalent) underneath.
+2. **EHDS Secure Processing Environments are not yet available.** NVIDIA FLARE's TEE is closest but requires NVIDIA hardware.
+3. **Lawful basis tracking is absent from all FL platforms.** Only Nuts (VCs with `purposeOfUse`) and HealthData@EU (permits) address this.
+4. **Audit trails are incomplete.** NEN 7513 requires patient-level logging. FL platforms log tasks, not patient-record access. This must be filled by pluginlake regardless of FL choice.
+5. **Patient rights (Wabvpz) are not addressed by any FL platform.** This is a data platform responsibility that constrains how FL can be deployed.
+
+---
+
+## 4. PLUGIN platform
+
+### 4.1 Module overview
+
+PLUGIN is a modular platform of independent packages:
+
+| Module | Purpose | Status |
+|---|---|---|
+| pluginlake | Data lakehouse: DuckDB/DuckLake, OMOP CDM, FHIR ingestion, Dagster, FastAPI gateway | Implemented |
+| pluginml | Federated ML: Flower-based aggregation, FederatedTransformer, training pipelines | Implemented (v0.3, on Flower + vantage6) |
+| pluginhub | Data exchange: secure federated data sharing between stations | Planned |
+| pluginanalytics | Federated queries: distributed SQL analytics across stations | Planned |
+
+Each module is a separate package with its own dependencies.
+pluginml is built on Flower (`flwr==1.22.0`) and vantage6 (`vantage6==4.13.0`), and can connect to a pluginlake instance as a data source.
+Together, these modules provide capabilities that FL platforms lack: structured healthcare data management, data cataloging, SQL-based federated queries, healthcare identity (via Nuts), data quality and provenance (via Dagster), and NEN 7513-compliant audit logging.
+
+### 4.2 Architecture options
+
+| Aspect | vantage6 only | Hybrid (vantage6 + Nuts) | Native decentralized (Nuts only) |
+|---|---|---|---|
+| Topology | Hub-and-spoke | Hub-and-spoke for compute, P2P for auth | Peer-to-peer |
+| Metadata visibility | Central server sees all | Server sees task metadata, auth in Nuts | Only participating stations |
+| Points of failure | Server + nodes | Server + nodes (auth survives outage) | Nodes only |
+| Auth strength | API keys + 2FA | PKIoverheid mTLS + VCs | PKIoverheid mTLS + VCs |
+| Algorithm validation | Tag-based whitelisting | Tags (v6) + digest/signature (Nuts VCs) | Digest-pinned, signed, attested |
+| Infra per station | v6 node + pluginlake | v6 node + pluginlake + Nuts Node | pluginlake + Nuts Node |
+| Central infra | v6 server + PostgreSQL + RabbitMQ | v6 server + PostgreSQL + RabbitMQ | Container registry only |
+| Time to production | Fastest | Medium | Slowest |
+| Long-term governance | Central operator required | Central operator for compute | Governance body for algorithm approval only |
+
+### 4.3 Hybrid scenario
+
+The hybrid keeps vantage6 for orchestration while complementing it with Nuts for organizational identity and per-request auth:
+
+**What it solves:** API-key auth upgraded to PKIoverheid mTLS + VCs (meeting NEN 7512), per-request node-to-node auth via Nuts OAuth2, per-request authorization via VCs (replacing shared encryption keys), and structured audit trail (Nuts + pluginlake logging).
+
+**What it does not solve:** the coordination model properties (hub-and-spoke topology, single connection per node, shared control/data plane) remain. These are acceptable for medium-scale federations and are separate from the auth concerns that Nuts addresses.
+
+**When it makes sense:** medium-scale federations (~5-20 organizations); leveraging the vantage6 ecosystem (IKNL algorithms, Health-RI collaborations); team bandwidth favors proven infrastructure over building new.
+
+### 4.4 Native decentralized option
+
+In a fully decentralized model, orchestration flows station-to-station via Nuts, following the KIK-V pattern generalized to container execution:
+
+```
+Requesting Station                     Data Station
+┌──────────────┐                      ┌──────────────┐
+│ pluginlake   │  1. Discover (Nuts)  │ pluginlake   │
+│ FastAPI      ├─────────────────────►│ FastAPI      │
+│              │  2. OAuth2 token     │              │
+│              │  3. POST /compute    │              │
+│              │     (image digest,   │  4. Verify   │
+│              │      params, VP)     │  5. Pull     │
+│              │                      │  6. Execute  │
+│              │◄─────────────────────┤  7. Sign     │
+│ 8. Aggregate │  signed result (JWS) │              │
+└──────────────┘                      └──────────────┘
+```
+
+No central server involved. The requesting station aggregates results from all participating stations locally.
+
+For federated queries (pluginanalytics), there is no iterative aggregation: each station returns a result, the requester combines them.
+For iterative model training (pluginml), the requesting station acts as the Flower aggregator.
+Privacy concerns (aggregator sees intermediate weights) can be addressed by Flower's SecAgg without requiring Flower's SuperLink infrastructure.
+
+### 4.5 Open questions
+
+1. **Multi-round aggregation privacy.** When the requesting station aggregates model weights, it sees all individual contributions. SecAgg hides these, but correct implementation is nontrivial. How much privacy risk is acceptable initially?
+
+2. **Container runtime isolation.** Running containers against patient data requires strong isolation. Options: network-isolated execution, read-only volumes, resource limits, gVisor/Kata. What level per validation level?
+
+3. **Large result transfer.** Intermediate model weights can be tens of megabytes. Is Nuts mTLS performant enough, or is a dedicated data channel needed?
+
+4. **Algorithm compatibility.** pluginml algorithms use vantage6's `@data()` and `@algorithm_client` decorators. A compatibility shim would be needed, or algorithms must be re-packaged.
+
+5. **pluginml migration path.** Replacing `PluginVantage6Client`, `run_v6`/`execute_v6_step`, and decorator patterns while keeping Flower integration (PLUGINClient, PLUGINStrategy) unchanged. Are there hidden coupling points?
+
+---
+
+## 5. Recommendation
+
+| Use case | Recommendation | Rationale |
+|---|---|---|
+| Federated aggregate queries | Build (pluginanalytics + Nuts) | FastAPI + DuckDB handles this. No FL framework needed. Queries bypass vantage6. |
+| Federated SQL analytics | Build (pluginanalytics) | DuckDB SQL + Nuts discovery/auth. No orchestrator needed. |
+| Secure data exchange | Build (pluginhub + Nuts) | Nuts provides discovery and auth. Avoids central server dependency. |
+| Container-based computation | Build (`/compute` endpoint + Nuts) | No new infrastructure. Container validation levels provide governance. |
+| Federated ML (short term) | Hybrid (Nuts auth on existing vantage6) | Keep pluginml on vantage6. Add Nuts for NEN 7512. Lowest disruption. |
+| Federated ML (long term) | Evaluate: reassess when federation exceeds vantage6's operational comfort zone (>20 nodes, high concurrency) | pluginml keeps Flower for ML. If scale demands outgrow vantage6's coordination model, the `/compute` endpoint provides a migration path. |
+| Federated deep learning (GPU) | Evaluate NVIDIA FLARE if GPU workloads become frequent | Requesting-station-as-aggregator works for rare GPU tasks. FLARE for frequent ones. |
+| vantage6 ecosystem interop | Build adapter (if needed) | Thin compatibility shim for existing `@algorithm_client`/`@data()` algorithms. |
+| Cross-border EHDS | Integrate with HealthData@EU when available (Release 5-6) | National access point adapter. |
+
+---
+
+## 6. User-facing access patterns
+
+Not every participant in the pluginlake network holds data.
+Hospitals run full data stations (FastAPI + DuckLake + Dagster + Nuts Node).
+Researchers or analytics teams may only need to query across stations.
+
+Every organization that participates needs its own DID and its own Nuts Node instance.
+The Nuts Node is [not multi-tenant](https://nuts-node.readthedocs.io/en/v5.4/pages/technology/saas.html): anyone with API access to a node can read all credentials on that node.
+A single shared node cannot safely serve multiple independent organizations.
+
+| Option | Description | Trade-off |
+|---|---|---|
+| Query station (self-hosted) | Minimal pluginlake deployment: FastAPI gateway + Nuts Node, no data pipeline. | Full identity sovereignty; requires local infra. |
+| Query station (cloud-hosted) | Multi-tenant query platform where each requesting organization gets its own Nuts Node container and gateway. | Low barrier to entry; hosting party manages infra but each org keeps its own DID. |
+| Piggyback on a data station | Researcher authenticates at a hospital's station and queries through it. Identity tied to the hospital's DID. | Simplest; but audit trail shows the hospital, not the researcher's organization. |
+
+Individual users never interact with Nuts directly.
+They authenticate against their organization's gateway using local auth (API key, OIDC, username/password), and the gateway handles Nuts-level federation on their behalf.
+
+**Onboarding friction.** The Nuts onboarding burden (DID registration, PKIoverheid certificate, Nuts Node deployment) is per-organization, not per-user, but non-trivial.
+The cloud-hosted option reduces this to an administrative step.
+Individual researchers never touch Docker, DIDs, or certificates.
+
+---
+
+## 7. EU dataspace detailed comparison
+
+This section provides detailed analysis of EU dataspace initiatives compared to Nuts Node for pluginlake.
+
+### Eclipse EDC / Tractus-X
+
+EDC is the reference implementation of DSP and DCP, wrapped by Tractus-X for automotive.
+It separates a Control Plane (catalog, negotiation, transfer protocol) from a Data Plane (HTTP, S3, blob transfer), uses `did:web` for identity, and enforces usage policies via ODRL.
+
+EDC offers full EU dataspace standard alignment, formal contract negotiation, and broad multi-sector adoption.
+However, it is written in Java/Kotlin with no Python SDK, requires 5+ services per participant, and has no healthcare-specific features: no patient-level authorization, no UZI/IRMA integration, no PKIoverheid CA hierarchy.
+
+### iSHARE
+
+iSHARE is a Dutch trust framework (logistics origin) using PKI-based identity, OAuth2 M2M auth, and a centralized Participant Registry.
+Its delegation model is production-proven in Dutch data spaces and Gaia-X aligned.
+
+For pluginlake, the main drawbacks are the semi-centralized Participant Registry dependency, the lack of healthcare-specific features, and certificate-based identity rather than DIDs/VCs.
+
+### Gaia-X
+
+Gaia-X is a governance overlay (trust framework, compliance labels), not deployable software.
+A pluginlake deployment could be Gaia-X-compliant while using Nuts Node for the actual identity/auth runtime.
+
+### EHDS and HealthData@EU
+
+EHDS is regulation, not technology (entered into force March 2025, application from 2029).
+The HealthData@EU Central Platform implements the cross-border routing layer using a four-corner model via eDelivery AS4 (Domibus).
+
+| Aspect | HealthData@EU Central Platform | pluginlake + Nuts Node |
+|---|---|---|
+| **Purpose** | EU-level secondary use catalogue and cross-border routing | Federated data lakehouse for multi-site clinical analytics |
+| **Scope** | National HDABs to Central Platform (regulatory level) | Hospital stations to research query stations (operational level) |
+| **Communication** | eDelivery AS4 (store-and-forward) | Direct HTTPS + gRPC (Nuts mTLS, synchronous) |
+| **Identity** | Delegated to member state; API keys between components | Decentralized DIDs + VCs (Nuts) per organization |
+| **AuthZ** | Data permits from Health Data Access Bodies | `NutsAuthorizationCredential` per collaboration (cryptographic) |
+| **Data flow** | Metadata catalogue sync; data via secure processing environments | Query at source; only aggregated results cross boundaries |
+
+These layers are complementary. If cross-border integration becomes required, a National Dispatcher adapter could translate between AS4 messages and pluginlake's REST API.
+
+### Why Nuts remains the recommended choice
+
+| Criterion | Nuts Node | EDC/Tractus-X | iSHARE |
+|---|---|---|---|
+| Healthcare fit | Purpose-built for Dutch healthcare | Generic (automotive focus) | Generic (logistics origin) |
+| Patient-level authz | `NutsAuthorizationCredential` per patient/resource | Not supported natively | Not supported natively |
+| Identity integration | IRMA/Yivi, UZI, PKIoverheid | `did:web` only | PKI certificates only |
+| Operational complexity | Single sidecar container (~200 MB) | 5+ services per participant | Participant Registry dependency |
+| Python ecosystem | REST API (httpx), sidecar pattern | Java/Kotlin only | REST API, limited libraries |
+| Decentralization | Fully P2P after bootstrap | P2P but needs DID web hosting | Semi-centralized |
+| Dutch healthcare adoption | Active deployments + Nuts Foundation | None | Limited healthcare adoption |
+| EU standards alignment | W3C DIDs + VCs (same primitives as DCP) | Full DSP + DCP | OAuth2 + PKI (DCP on roadmap) |
+
+### Future-proofing strategy
+
+- **Phase 1 (now):** Adopt Nuts Node for inter-station auth in the Dutch healthcare context.
+- **Phase 2 (~2027):** Evaluate whether Nuts evolves toward DCP or whether a lightweight DSP adapter is needed.
+- **Phase 3 (~2029):** If cross-border exchange is required, add a DSP control plane that delegates identity to Nuts Node.
+
+---
+
+## 8. Regulatory compliance for clinical data exchange
+
+pluginlake exchanges clinical (health) data between federated stations.
+This section maps each regulation to its key requirements and assesses compliance posture.
+
+### EU regulations
+
+#### GDPR (Regulation (EU) 2016/679)
+
+Health data are "special category" data under Article 9.
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Lawful basis (Art. 6 + Art. 9) | Planned | Each station's controller must establish lawful basis per use case. |
+| DPIA (Art. 35) | Not started | Required before deploying processing of health data at scale. |
+| Data minimisation (Art. 5(1)(c)) | Partial | API endpoints can scope responses; not yet enforced systematically. |
+| Right of access/portability (Art. 15, 20) | Partial | FastAPI exposes data per patient, but no self-service portal yet. |
+| Breach notification (Art. 33-34) | Not implemented | 72-hour notification to AP required. |
+| Records of processing (Art. 30) | Not implemented | Must document all processing activities per station. |
+
+#### EHDS (Regulation (EU) 2025/327)
+
+Entered into force March 2025. Application phased: 2027 (digital health authorities), 2029 (primary+secondary use rights), 2031 (extended primary use).
+
+| Requirement | Status | Notes |
+|---|---|---|
+| European EHR exchange format (Art. 15) | Partial | pluginlake uses FHIR; implementing acts for exact format due March 2027. |
+| Patient access to health data (Art. 3) | Not started | Required from 2029. |
+| EHR system conformity (Art. 39, Annex II) | Not started | Manufacturers must demonstrate conformity (CE marking). |
+| Secondary use via HDABs (Ch. IV) | Not applicable yet | Pseudonymisation and secure processing environment required. |
+| Logging of access (Annex II, 3.2) | Planned | Nuts Node + FastAPI middleware log access events. |
+| Right to opt out (Art. 71) | Not started | Must implement when secondary use is supported. |
+
+#### NIS2 (Directive (EU) 2022/2555)
+
+Covers healthcare as a critical sector.
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Risk management (Art. 21) | Partial | Nuts mTLS, encrypted storage, access controls. Formal risk assessment not documented. |
+| Incident reporting (Art. 23) | Not implemented | 24h early warning, 72h full notification to CSIRT. |
+| Supply chain security (Art. 21(2)(d)) | Partial | Dependencies via `uv`/`pyproject.toml`. No formal SBOM. |
+| Business continuity (Art. 21(2)(c)) | Not implemented | Backup, disaster recovery, crisis management needed. |
+
+#### CRA (Regulation (EU) 2024/2847)
+
+Applies from December 2027. Medical devices excluded from CRA but EHDS requires EHR systems to demonstrate CRA conformity.
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Software Bill of Materials (Annex I, Part II) | Not implemented | Generate from `pyproject.toml`/`uv.lock`. |
+| Vulnerability handling (Annex I, Part II) | Not implemented | Coordinated vulnerability disclosure needed. |
+| Security by design (Annex I, Part I) | Partial | Nuts mTLS, JWT validation, role-based access. Need threat model. |
+
+#### eIDAS (Regulation (EU) No 910/2014, amended by eIDAS2 (EU) 2024/1183)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Accept eIDAS-recognised eID for patient access | Not started | Required when patient-facing services are built. |
+| Health professional auth via recognised eID | Planned | Nuts supports IRMA/Yivi and UZI (Dutch eID aligned). |
+| PKIoverheid certificates for machine identity | Planned | Required for Nuts Node production deployment. |
+
+### Dutch regulations and standards
+
+#### Wegiz (Stb. 2023, 99)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Electronic exchange of designated data | Partial | pluginlake supports FHIR-based exchange. AMvB alignment TBD. |
+| Use of designated standards | Partial | Depends on AMvB-prescribed standards per exchange type. |
+
+#### Wabvpz (Stb. 2017, 446)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Patient electronic access to records | Not started | No patient-facing portal yet. |
+| Logging of all access to patient records | Planned | Nuts Node + FastAPI middleware. NEN 7513 format TBD. |
+| Patient consent for electronic exchange | Planned | `NutsAuthorizationCredential` can encode patient-level consent. UX needed. |
+
+#### NEN 7510 (Information security management in healthcare)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| ISMS | Not started | Documented policies, risk assessment, continuous improvement. Organizational per station. |
+| Access control | Partial | Nuts identity + FastAPI RBAC. Formal policy not documented. |
+| Cryptographic controls | Partial | mTLS (TLS 1.3), JWT signing, DuckDB encryption at rest. Key management TBD. |
+
+#### NEN 7512 (Trusted electronic communication)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Authentication of communicating parties | Compliant | Nuts mTLS with PKIoverheid certificates. |
+| Communication security | Compliant | gRPC with mTLS; HTTPS with JWT tokens. |
+| Trust establishment | Compliant | DID-based trust with VCs and network consensus. |
+
+#### NEN 7513 (Logging of access to health records)
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Log: user identity, role, organization | Planned | Nuts token provides `sub`, `iss`, `purposeOfUse`. |
+| Log: patient identity | Planned | Link each access event to the patient(s) whose data were accessed. |
+| Log: timestamp, action type | Planned | FastAPI middleware captures this. Format per NEN 7513 TBD. |
+| Log retention (min. 5 years per Wabvpz) | Not implemented | Need durable, tamper-evident storage per station. |
+
+### Compliance summary
+
+| Regulation | Layer | Current | With Nuts | Key gaps |
+|---|---|---|---|---|
+| GDPR | EU | Partial | Improved | DPIA, breach procedures, records of processing |
+| EHDS | EU | Low | Improved | Patient access, exchange format, EHR certification |
+| NIS2 | EU | Low | Improved | Risk assessment, incident reporting, business continuity |
+| CRA | EU | N/A yet | Improved | SBOM, vulnerability handling |
+| eIDAS | EU | Not started | Improved | Cross-border eID, wallet integration |
+| Wegiz | NL | Partial | Improved | AMvB-designated standard alignment |
+| Wabvpz | NL | Low | Improved | Patient portal, consent UX, log retention |
+| NEN 7510 | NL | Low | Improved | ISMS, documented policies |
+| NEN 7512 | NL | Good | Compliant | Minimal gaps |
+| NEN 7513 | NL | Low | Improved | Formatted audit log, retention policy |
+
+### Key compliance actions (priority order)
+
+1. **Complete a DPIA** (GDPR Art. 35) before production deployment with real patient data.
+2. **Document an ISMS** (NEN 7510) or align with the station operator's existing ISMS.
+3. **Implement structured audit logging** per NEN 7513, with 5-year retention (Wabvpz).
+4. **Establish incident response procedures** for GDPR (72h) and NIS2 (24h early warning).
+5. **Generate SBOMs** from `uv.lock` for CRA readiness.
+6. **Verify Wegiz alignment** per AMvB-designated data exchanges.
+7. **Plan a patient access service** for Wabvpz and EHDS (Art. 3-4) by 2029.
+8. **Monitor EHDS implementing acts** (due March 2027) for exchange format and certification requirements.
+
+---
+
+## 10. Operational design for federated query dispatch
+
+This section documents the operational design for executing federated queries across multiple datastations, covering async dispatch, result management, failure handling, versioning, rate limiting, and monitoring.
+These concerns are referenced by [ADR-006](../decisions/adr-006-nuts-node-decentralized-auth.md) (architecture) and Epic E6 in the [Epics & Stories](../decisions/epics-analytics.md) (implementation).
+
+### 10.1 Async dispatch via Dagster
+
+Dagster jobs on datastations are asynchronous. The CPU does not maintain a long-running HTTP connection.
+The dispatch pattern is:
+
+1. The CPU calls `POST /execute` on the datastation with the query asset name, parameters, and Nuts JWT.
+2. The datastation validates the token and parameters, starts a Dagster run, and returns `202 Accepted` with a `query_id`.
+3. The CPU polls `GET /execute/{query_id}/status` periodically. Possible statuses: `pending`, `running`, `completed`, `failed`, `expired`.
+4. On `completed`, the CPU retrieves the result via `GET /execute/{query_id}/result`.
+5. The CPU repeats 3-4 for each datastation in the query.
+
+Polling is preferred over push notifications because:
+
+- The CPU controls retry logic and timing.
+- No reverse auth direction needed (the datastation would need a Nuts token to call back the CPU).
+- If the CPU is temporarily unreachable, no push is lost: results wait on the datastation.
+- Polling is battle-tested in federated systems (Flower, EHDS proposals, S3 multipart).
+
+The CPU manages polling state internally. This maps naturally to a Dagster sensor on the CPU side that checks pending queries across datastations.
+
+### 10.2 Result storage and TTL
+
+Query results are stored on the datastation with a configurable TTL (e.g. 24 hours). After the TTL expires, the result is deleted and the status changes to `expired`.
+
+**Result expiry is a real risk.** If the CPU dispatches to 10 datastations and takes 2 hours to retrieve the last result (because the first 9 took long), station 10's result may have expired. The CPU must handle `expired` status by re-dispatching that specific station.
+
+Design requirements:
+
+- The TTL must be long enough to accommodate the slowest query in the federation plus polling overhead.
+- The CPU should track per-station result age and prioritize retrieval of results approaching TTL.
+- Results are never persisted beyond their TTL. This supports the "no raw data stored on CPU" policy: the datastation controls how long intermediate results exist.
+
+### 10.3 Token renewal during long queries
+
+Nuts JWTs have a short TTL (configurable, typically minutes). For long-running async queries, the CPU must re-obtain tokens for each polling call.
+
+This is cheap: token acquisition from the local Nuts Node is a localhost call with no network round-trip. The credential is still valid (its lifetime is much longer than the token's). The overhead is negligible.
+
+However: if the underlying `NutsAuthorizationCredential` is revoked while a query is in progress, the CPU can no longer obtain new tokens. The in-flight query continues on the datastation (it was already started), but the CPU cannot retrieve the result. This is correct behavior: revocation means "access revoked now," not "access revoked retroactively."
+
+### 10.4 Partial failure and manifest
+
+When the CPU dispatches to multiple datastations, some may fail or time out. The SDC correctness guarantee depends on complete results (a group of 2 at Hospital A and 3 at Hospital B is a group of 5 in total: safe to release, but suppressed if each hospital applied SDC independently).
+
+**Architectural policy: SDC correctness is only guaranteed on complete results.**
+
+The CPU returns a manifest with every query response:
+
+```json
+{
+  "manifest": {
+    "total_datastations": 10,
+    "completed": ["did:nuts:hosp-a", "did:nuts:hosp-b", ...],
+    "failed": [
+      {"did": "did:nuts:hosp-c", "reason": "timeout", "retryable": true},
+      {"did": "did:nuts:hosp-d", "reason": "version_incompatible", "retryable": false}
+    ]
+  },
+  "is_complete": false,
+  "sdc_applied": true,
+  "result": { ... }
+}
+```
+
+The CPU never silently drops failed datastations. The data user decides whether a partial result is usable.
+
+### 10.5 Versioning and catalog compatibility
+
+Hospitals upgrade pluginlake at different paces. The catalog is the compatibility checkpoint.
+
+The `GET /catalog` response includes per query asset:
+
+- `name`: the asset identifier (e.g. `count_per_group`).
+- `description`: human-readable description.
+- `parameter_schema`: JSON Schema of accepted parameters.
+- `schema_version`: semantic version of the parameter schema (e.g. `1.2.0`).
+- `pluginlake_version`: the pluginlake version that introduced this asset version.
+
+Before dispatching, the CPU compares the `schema_version` in the datastation's catalog against the version it expects:
+
+- **Same major version:** compatible. The CPU dispatches normally.
+- **Different major version:** breaking change. The CPU skips the datastation and records a `version_incompatible` error in the manifest.
+- **Minor version difference:** the CPU adapts if possible (e.g. uses only parameters that the older schema supports) or skips.
+
+The version check happens *from the cached catalog*, not as a separate pre-dispatch call. The catalog is refreshed periodically (e.g. every hour) and on-demand when dispatching.
+
+### 10.6 Rate limiting at the gateway
+
+Dagster's internal run concurrency limits manage resource allocation on a single instance. They do not protect against external load.
+
+The problem: if 5 CPUs each fire 10 queries, that's 50 incoming HTTP requests. Every request is accepted, authenticated (Nuts introspection), and handed to Dagster before concurrency limits kick in. The gateway connections, Nuts Node CPU for introspection, and Dagster scheduling overhead are all consumed.
+
+The datastation must protect itself at the gateway level:
+
+- **Per-CPU DID rate limit in FastAPI middleware:** max concurrent query executions (e.g. 5) and max queries per minute (e.g. 30).
+- **`429 Too Many Requests`** with `Retry-After` header: instant signal to the CPU to back off.
+- **CPU implements exponential backoff** when receiving `429`.
+- Rate limits are configurable per CPU DID (a high-priority CPU can get higher limits).
+
+Dagster's concurrency limits are a safety net (defense in depth), not the rate limiting mechanism.
+
+### 10.7 Health checks and monitoring
+
+Each node exposes health status for operational monitoring:
+
+- **Nuts Node:** health endpoint on port 1323. Hard dependency: if down, the station is unreachable. Restart on failure.
+- **Datastation health:** composite endpoint reporting Nuts Node status, Dagster daemon status, DuckLake connectivity.
+- **CPU health:** reports Nuts Node status plus reachability of all configured datastations (last successful catalog fetch, last successful query).
+
+For initial deployment, health checks are HTTP endpoints consumed by Docker health checks or a monitoring system. Prometheus metrics export (query latency, failure rate, rate limit hits per CPU DID) is a future optimization.
+
+---
+
+## 9. References
+
+### Papers
+
+- Lo, S.K., et al. (2022). Architectural patterns for the design of federated learning systems. *J. Systems & Software*, 191, 111357. [doi:10.1016/j.jss.2022.111357](https://doi.org/10.1016/j.jss.2022.111357)
+- "A federated infrastructure for European data spaces." *Commun. ACM*, 65 (2022): 44-45. [doi:10.1145/3512341](https://doi.org/10.1145/3512341)
+- Mammen, P.M. (2021). Federated Learning: Opportunities and Challenges. [arXiv:2101.05428](https://arxiv.org/abs/2101.05428)
+- Li, Q., et al. (2021). A survey on federated learning. *Knowledge-Based Systems*, 216, 106775. [doi:10.1016/j.knosys.2021.106775](https://doi.org/10.1016/j.knosys.2021.106775)
+- "Federated learning: Overview, strategies, applications, tools and future directions." *Heliyon* (2024). [doi:10.1016/j.heliyon.2024.e38168](https://doi.org/10.1016/j.heliyon.2024.e38168)
+
+### Platform documentation
+
+- [Nuts Node documentation (v5.4)](https://nuts-node.readthedocs.io/en/v5.4/)
+- [KIK-V publication platform](https://kik-v-publicatieplatform.nl/)
+- [KIK-V program](https://kik-v.nl/)
+- [HealthData@EU Central Platform](https://acceptance.data.health.europa.eu/)
+- [EHDS2 Release 3 Architecture](https://op.europa.eu/en/publication-detail/-/publication/52fe4b0e-0ac4-11f0-b1a3-01aa75ed71a1)
+- [HDEU source code](https://code.europa.eu/healthdataeu/healthdataeu-eu-dataset-catalogue)
+- [Flower documentation](https://flower.ai/docs/)
+- [vantage6 documentation](https://docs.vantage6.ai/)
+- [NVIDIA FLARE documentation](https://nvflare.readthedocs.io/)
+- [PySyft repository](https://github.com/OpenMined/PySyft)
+- [OpenFL documentation](https://openfl.readthedocs.io/)
+- [Brane repository (archived)](https://github.com/epi-project/brane)
+- [Substra documentation](https://docs.substra.org/)
+- [TensorFlow Federated](https://www.tensorflow.org/federated)
+
+### Project documentation
+
+- Vinkesteijn, Y. (2025). *Vantage6 Production Readiness Assessment.* PLUGIN / DHD. [docs/papers/production-readiness-assessment.md](../papers/production-readiness-assessment.md)
+
+### Regulations
+
+- [GDPR — Regulation (EU) 2016/679](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [EHDS — Regulation (EU) 2025/327](https://eur-lex.europa.eu/eli/reg/2025/327/oj)
+- [NIS2 — Directive (EU) 2022/2555](https://eur-lex.europa.eu/eli/dir/2022/2555/oj)
+- [CRA — Regulation (EU) 2024/2847](https://eur-lex.europa.eu/eli/reg/2024/2847/oj)
+- [eIDAS — Regulation (EU) No 910/2014](https://eur-lex.europa.eu/eli/reg/2014/910/oj)
+- [eIDAS2 — Regulation (EU) 2024/1183](https://eur-lex.europa.eu/eli/reg/2024/1183/oj)
+- [NEN 7510-1:2024](https://www.nen.nl/nen-7510-1-2024-nl-312618)
+- [NEN 7512:2022](https://www.nen.nl/nen-7512-2022-nl-297498)
+- [NEN 7513:2023](https://www.nen.nl/nen-7513-2023-nl-308704)
+- [Wegiz](https://wetten.overheid.nl/BWBR0047840/)
+- [Wabvpz](https://wetten.overheid.nl/BWBR0023864/)
+
+### Dataspace technology
+
+- [W3C Decentralized Identifiers (DIDs)](https://www.w3.org/TR/did-core/)
+- [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/)
+- [Eclipse DCP v1.0.1](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0.1/)
+- [Eclipse DSP](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol)
+- [Eclipse Tractus-X Connector KIT](https://eclipse-tractusx.github.io/docs-kits/kits/connector-kit/adoption-view)
+- [iSHARE Trust Framework](https://framework.ishare.eu/)
+- [Gaia-X Architecture](https://gaia-x.eu/what-is-gaia-x/)
+- [HEALTH-X dataLOFT](https://www.health-x.org/home)
+- [HDEU Dispatcher](https://code.europa.eu/healthdataeu/healthdataeu-eu-dataset-catalogue/hdeu-dispatcher)
+- [eDelivery Building Block](https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eDelivery)

--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -1,0 +1,10 @@
+# Background
+
+In-depth design specifications, platform research, and architectural context that inform pluginlake's technical decisions.
+
+These documents evolve as the project matures. They provide the detailed "how" and "why" behind the architecture, complementing the concise [ADRs](../decisions/README.md) which record what was decided.
+
+| Document | Description |
+|----------|-------------|
+| [Federated Infrastructure](federated-infrastructure.md) | Platform comparison: Nuts, vantage6, Flower, NVIDIA FLARE, EU dataspaces. Evaluates architecture, auth, privacy, and regulatory compliance. |
+| [DSP Authorization Architecture](dsp-authorization.md) | Design specification for the Dataspace Protocol integration, ODRL enforcement, RBAC, and phased delivery plan. |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,3 +9,5 @@ This directory contains Architecture Decision Records (ADRs) for the pluginlake 
 | [ADR-003](adr-003-ducklake-data-catalog.md)     | DuckLake integration with Dagster + logging      | Proposed | 2026-02-23 |
 | [ADR-004](adr-004-data-organization.md)         | Data organization and naming conventions         | Proposed | 2026-02-24 |
 | [ADR-005](adr-005-fastapi-gateway.md)           | FastAPI as unified API gateway                   | Proposed | 2026-03-05 |
+| [ADR-006](adr-006-nuts-node-decentralized-auth.md) | Nuts Node integration for decentralized identity | Accepted | 2026-03-19 |
+| [ADR-007](adr-007-dataspace-protocol-authz-authc-rbac.md) | DSP, authentication, and authorization architecture | Proposed | 2026-05-28 |

--- a/docs/decisions/adr-003-ducklake-data-catalog.md
+++ b/docs/decisions/adr-003-ducklake-data-catalog.md
@@ -102,7 +102,7 @@ Dagster is not in the read path because reads don't mutate data and routing thro
 | Approach                                                    | Rejected because                                                                              |
 |-------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | Synchronous (FastAPI validates + writes + notifies Dagster) | User waits for full pipeline. Dagster only gets a notification, not lineage                   |
-| Landing zone (FastAPI → staging → Dagster)                  | Adds complexity and decouples ingestion from processing. Staging area needed for raw payloads |
+| Decoupled landing zone (FastAPI dumps to disk, Dagster polls/watches) | Decouples ingestion from processing — Dagster discovers files independently rather than being triggered directly. Adds complexity without benefit since FastAPI already knows when to trigger |
 
 ---
 

--- a/docs/decisions/adr-006-nuts-node-decentralized-auth.md
+++ b/docs/decisions/adr-006-nuts-node-decentralized-auth.md
@@ -80,7 +80,7 @@ services:
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     ports:
-      - "1323:1323"  # internal API (localhost only)
+      - "127.0.0.1:1323:1323"  # internal API (localhost only)
       - "5555:5555"  # gRPC (public, mTLS)
     volumes:
       - "./config/nuts/nuts.yaml:/opt/nuts/nuts.yaml:ro"

--- a/docs/decisions/adr-006-nuts-node-decentralized-auth.md
+++ b/docs/decisions/adr-006-nuts-node-decentralized-auth.md
@@ -1,336 +1,77 @@
-# ADR-006: Nuts Node for decentralized authentication and authorization
+# ADR-006: Nuts Node integration for decentralized organizational identity
 
-**Status:** Proposed
-**Date:** 2026-03-19
+**Status:** Accepted
+**Date:** 2026-03-19 (revised 2026-05-28)
+
+## TL;DR
+
+This ADR defines how pluginlake integrates [Nuts](https://nuts-node.readthedocs.io/) as the decentralized identity layer for inter-node communication (trust boundary 2: node-to-node). Nuts handles organizational identity only. Per-user authorization, contract negotiation, and enforcement are defined in [ADR-007](adr-007-dataspace-protocol-authz-authc-rbac.md).
+
+**Scope of Nuts in pluginlake:**
+
+| Nuts does | Nuts does NOT do |
+|---|---|
+| Prove which organization operates a node | Decide what a specific user may access |
+| Establish bilateral trust between nodes | Negotiate data access contracts (→ DSP, ADR-007) |
+| Provide network membership discovery | Enforce per-dataset or per-query permissions (→ ODRL, ADR-007) |
+| Validate DPoP proofs per request | Issue or verify per-user credentials (→ PluginlakeAccessCredential, ADR-007) |
+
+---
 
 ## Context
 
-pluginlake is a federated data lakehouse where each hospital runs its own data station.
-Stations need to exchange data and query each other's APIs (see [ADR-005](adr-005-fastapi-gateway.md)) without relying on a single central identity provider.
+pluginlake is a federated data lakehouse where hospitals run data stations and research coordinators run processing hubs.
+Nodes need to identify each other without relying on a single central identity provider.
 
-The FastAPI gateway currently has placeholder auth ([security.py](../../src/pluginlake/api/security.py) returns an anonymous user for every request).
-We need a solution that:
+Requirements:
 
-- Authenticates requests between stations without a central auth server.
-- Authorizes access to specific data per organization.
-- Provides an audit trail for healthcare compliance (NEN 7510, AVG/GDPR).
-- Fits the federated model where each station is sovereign over its own data.
+- Authenticate requests between nodes without a central auth server.
+- Prove organizational identity cryptographically (which hospital, which research institute).
+- Provide an audit trail for healthcare compliance (NEN 7510, AVG/GDPR).
+- Fit the federated model where each station is sovereign over its own data.
+- Integrate with the Dutch healthcare ecosystem (Nuts is already adopted by 100+ organizations).
 
-[Nuts Node](https://nuts-node.readthedocs.io/en/v5.4/) is an open-source, Dutch healthcare-specific infrastructure component that provides decentralized identity, authentication, and authorization using W3C standards.
+[Nuts Node](https://nuts-node.readthedocs.io/en/v5.4/) is an open-source, Dutch healthcare-specific infrastructure component that provides decentralized identity using W3C DIDs and Verifiable Credentials.
+
+---
 
 ## Decision
 
-**Adopt Nuts Node as the decentralized auth layer for inter-station communication, integrated as FastAPI middleware.**
+**Adopt Nuts Node as the decentralized organizational identity layer, integrated as a FastAPI middleware sidecar. Nuts handles trust boundary 2 (node-to-node) exclusively.**
 
-### Architecture
+---
 
-```
-Data user (org)          Processing Hub (role: Processing Hub)                      Datastation (role: datastation)
-                    ┌──────────────────────┐                 ┌──────────────────────┐
-  Nuts or OIDC      │  pluginlake API      │                 │  pluginlake API      │
-  (org-verified)    │  ┌────────────────┐  │   Nuts JWT      │  ┌────────────────┐  │
- ──────────────────►│  │  FastAPI       │  │  (purposeOfUse) │  │  FastAPI       │  │
-                    │  │  gateway       │◄─┼────────────────►│  │  gateway       │  │
-                    │  │  ┌───────────┐ │  │                 │  │  ┌───────────┐ │  │
-                    │  │  │ Nuts auth │ │  │                 │  │  │ Nuts auth │ │  │
-                    │  │  │ middleware│ │  │                 │  │  │ middleware│ │  │
-                    │  │  └───────────┘ │  │                 │  │  └───────────┘ │  │
-                    │  │  + SDC assets  │  │                 │  │  + query assets│  │
-                    │  └────────────────┘  │                 │  └────────────────┘  │
-                    │                      │                 │                      │
-                    │  ┌────────────────┐  │  gRPC (mTLS)    │  ┌────────────────┐  │
-                    │  │  Nuts Node     │◄─┼───────────────► │  │  Nuts Node     │  │
-                    │  │  (sidecar)     │  │                 │  │  (sidecar)     │  │
-                    │  └────────────────┘  │                 │  └────────────────┘  │
-                    └──────────────────────┘                 └──────────────────────┘
+## Architecture
 
-  Every cross-org boundary uses Nuts-verified organizational identity.
-  Same pluginlake software. Role determined by config + Nuts credentials.
-```
+### Sidecar deployment
 
-### Middleware integration
-
-The Nuts Node runs as a sidecar container alongside the pluginlake services.
-A FastAPI middleware validates incoming inter-station requests on every node (both Processing Hub and datastation):
-
-1. Extract the JWT access token from the `Authorization` header.
-2. Introspect it via the Nuts Node's `/internal/auth/v1/accesstoken/introspect` endpoint (localhost, no network round-trip).
-3. Populate the request context with the authenticated identity (`organization`, `purposeOfUse`).
-4. The existing `require_role`/`require_auth` dependencies in `security.py` use this context for route-level authorization.
-
-For requests from data users to the Processing Hub, the user's organizational identity must also be verified (see Data user authentication below).
-The Nuts middleware activates for any cross-organizational call, whether between stations or from a data user to the Processing Hub.
-For purely local admin requests (CLI on the same machine), a local API key may be used.
-
-### Data user authentication
-
-#### How Nuts handles identity: organizations and users
-
-Nuts operates at the **organization level**. Each DID (`did:nuts`) represents a care organization (a hospital, registry, or research institute), not an individual user.
-
-User identity is a separate layer built into the Nuts OAuth2 flow. When a user wants to act on behalf of an organization, they sign a "contract" — a statement like "I hereby declare to act on behalf of Hospital X." Nuts supports two mechanisms for this:
-
-- **Employee Identity:** the organization's system vouches for the user by providing their identifier, name, and role to the Nuts Node, which creates a Verifiable Presentation (VP).
-- **IRMA:** the user proves their identity via the IRMA app using citizen credentials (BRP, email), independently verified.
-
-The signed contract (VP) is included when the Nuts Node requests an OAuth2 access token from the receiving party's Nuts Node. The resulting JWT therefore carries *both* organizational identity *and* user identity. When the receiving party introspects the token, it sees: `username`, `initials`, `family_name`, `assurance_level`, plus the organization's DID.
-
-This is important: **Nuts does not treat user authentication as something separate from the organization flow.** The user contract is embedded in the same OAuth2 token exchange that authenticates the organization.
-
-#### Multi-tenancy: one Nuts Node per organization
-
-The Nuts Node is explicitly **not multi-tenant** ([SaaS Considerations](https://nuts-node.readthedocs.io/en/v5.4/pages/technology/saas.html#multi-tenancy)). Anyone with access to a Nuts Node's API can read and use any credential present on it. The Nuts documentation recommends running a separate Nuts Node for each organization.
-
-This has a direct implication for the Processing Hub. If the Processing Hub only serves users from its own organization (e.g. IKNL Data users using the IKNL Processing Hub), one Nuts Node with one DID is sufficient. But if the Processing Hub serves users from *multiple* organizations (an Amsterdam UMC Data user and a Leiden UMC Data user both querying the same IKNL Processing Hub), the Processing Hub needs a way to handle multi-org user access.
-
-#### What this means for the data user → Processing Hub boundary
-
-The data user → Processing Hub interaction is a cross-organizational boundary. A Data user from Amsterdam UMC querying the IKNL Processing Hub must be identified as an Amsterdam UMC employee, not as a generic "IKNL user."
-
-The Nuts-native way to handle this: the user's organization (Amsterdam UMC) has its own Nuts Node. The Data user signs a `PractitionerLogin` contract at Amsterdam UMC's Nuts Node. That VP is included in an access token request to the Processing Hub's Nuts Node. The Processing Hub introspects the token and gets: the user's identity (name, email) + the user's organization DID (Amsterdam UMC) + that the token was issued for `purposeOfUse: pluginlake-query-access`.
-
-The flow looks like this:
-
-1. Data user opens the Processing Hub's web UI or Python client.
-2. The Processing Hub redirects to the Data user's organization's Nuts Node (or the Data user provides their org's DID).
-3. The Data user signs a `PractitionerLogin` contract (Employee Identity or IRMA).
-4. Amsterdam UMC's Nuts Node obtains an access token from the Processing Hub's Nuts Node, including the signed VP.
-5. The Processing Hub validates the token via introspection: gets org DID + user identity.
-6. The Processing Hub looks up which `NutsAuthorizationCredential`s exist for Amsterdam UMC's DID → determines which collaborations and catalogs the Data user can access.
-7. Only results from those federations are visible to this Data user.
-
-This means every consuming organization needs a Nuts Node, which is realistic since most participating organizations already run one as a datastation. The user never interacts with Nuts directly — the contract signing happens through the UI, similar to an SSO redirect.
-
-#### Alternative: federated OIDC with DID binding
-
-If requiring every consumer organization to have a Nuts Node is too restrictive (e.g. academic Data users at institutions without healthcare infrastructure), an alternative is to accept institutional OIDC tokens (SURFconext, Entra ID) and map the OIDC issuer to a known Nuts DID. This is simpler for the user (standard SSO login) but introduces a mapping that must be maintained and verified. See governance question 6.
-
-#### Result: unified request context
-
-Regardless of the mechanism, after authentication the Processing Hub's request context contains:
-
-- `user_identity`: the user's name, identifier, role (from the VP or OIDC claims).
-- `organization_did`: the verified DID of the user's organization (from Nuts token introspection or OIDC-to-DID mapping).
-- `accessible_collaborations`: which `NutsAuthorizationCredential`s exist for that organization DID (derived at request time).
-
-This context is used for credential-scoped access control, audit logging (who from which organization queried what), and ensuring a Data user can only see results from collaborations their organization participates in.
-
-### Node roles: Processing Hub and datastation
-
-Every node in the network runs the same pluginlake software.
-What a node *does* is determined by two things: its local configuration and the Nuts credentials it holds.
-
-| Aspect | Datastation | Processing Hub |
-|---|---|---|
-| Local data | Yes (DuckLake, OMOP CDM, FHIR ingestion) | No (data ingestion disabled) |
-| Query assets (Dagster) | Yes (executes queries on local data) | No (dispatches queries to datastations) |
-| SDC assets (Dagster) | No | Yes (applies statistical disclosure control on combined results) |
-| Nuts Node | Yes (own DID) | Yes (own DID) |
-| Nuts auth middleware | Yes (validates Processing Hub requests) | Yes (validates datastation responses, incoming admin calls) |
-| Receives queries from | Processing Hub (via Nuts JWT) | Data users (via org-verified auth) |
-| Issues credentials to | Processing Hub's DID (grants data access) | Nobody (receives credentials from datastations) |
-
-A pluginlake configuration option (e.g. `role: Processing Hub` or `role: datastation`) activates the correct modules.
-The gateway enforces this role by checking `purposeOfUse` values:
-
-- A datastation rejects outgoing requests with `purposeOfUse: pluginlake-query-dispatch` (only Processing Hubs dispatch).
-- A Processing Hub rejects incoming requests that try to execute local query assets (it has no data).
-
-This means there is no separate Processing Hub codebase.
-Adding a Processing Hub to the network is deploying another pluginlake instance with a different config profile and its own Nuts Node.
-
-### What is a collaboration?
-
-A collaboration in the PLUGIN network is a bilateral trust agreement between a datastation (hospital) and a Processing Hub (research coordinator).
-
-In concrete terms, a collaboration is one digital credential: a `NutsAuthorizationCredential` issued by a datastation to a Processing Hub.
-This credential is the datastation saying: "I, Hospital X, allow Processing Hub Y to query these specific tables, with these filters, until this date."
-
-That single credential *is* the collaboration.
-There is no central registry, no approval board, no shared database of collaborations.
-The credential lives on the Nuts network, visible only to the two parties involved.
-
-A **federation** is the collection of all bilateral credentials that point to one Processing Hub.
-When IKNL (oncology Processing Hub) has credentials from 15 hospitals, that set of 15 credentials *is* the IKNL oncology federation.
-Each hospital independently decided to participate by issuing its own credential.
-Each hospital can revoke its credential at any time, instantly leaving the federation.
-
-What this means in practice:
-
-- **Starting a collaboration:** the datastation operator issues a credential to the Processing Hub's DID through the pluginlake UI.
-- **Ending a collaboration:** the datastation operator revokes the credential. The Processing Hub can no longer obtain access tokens.
-- **Changing scope:** the datastation revokes the old credential and issues a new one with different table, filter, or time period permissions.
-- **No central authority:** nobody except the datastation can grant or revoke access to its data.
-
-### Network topology and role identity
-
-The PLUGIN network supports many-to-many relationships between Processing Hubs and datastations.
-Multiple Processing Hubs can exist (e.g. IKNL for oncology, DHD for quality indicators, a university for a specific study), and each Processing Hub independently receives bilateral credentials from whichever datastations participate in its collaboration.
-A single datastation can issue credentials to multiple Processing Hubs.
+Each pluginlake instance (hub or station) runs a Nuts Node as a sidecar container:
 
 ```
-                 Processing Hub-A (oncology)
-                  ┌───┐
-         ┌───────►│DID│◄────────┐
-         │        └───┘         │
-    credential              credential
-         │                      │
-     ┌───┴───┐              ┌───┴───┐
-     │Hosp. 1│              │Hosp. 2│
-     └───┬───┘              └───┬───┘
-         │                      │
-    credential              credential
-         │        ┌───┐         │
-         └───────►│DID│◄────────┘
-                  └───┘
-                 Processing Hub-B (quality registry)
+┌──────────────────────────┐
+│  pluginlake instance     │
+│  ┌────────────────────┐  │
+│  │  FastAPI gateway    │  │
+│  │  ┌──────────────┐  │  │
+│  │  │ Nuts auth    │  │  │
+│  │  │ middleware   │  │  │
+│  │  └──────────────┘  │  │
+│  └────────────────────┘  │
+│                          │
+│  ┌────────────────────┐  │
+│  │  Nuts Node         │  │
+│  │  (sidecar)         │  │
+│  │  - own DID         │  │
+│  │  - NutsOrgCred     │  │
+│  │  - DPoP validation │  │
+│  └────────────────────┘  │
+└──────────────────────────┘
+         │ gRPC (mTLS)
+         ▼
+  Other Nuts Nodes in network
 ```
 
-Technically, Processing Hub and datastation are the same pluginlake software.
-What makes a node a "Processing Hub" or a "datastation" is the combination of three things:
-
-1. **Dagster definitions (configuration):** which asset groups and code locations are loaded. pluginlake already composes definitions via `Definitions.merge()` in `pluginlake/definitions/` (see [ADR-001](adr-001-asset-architecture.md)). A datastation loads the existing data ingestion definitions (`pluginlake.definitions.omop`, `pluginlake.definitions.fhir`) plus a new **aggregate definitions** module (`pluginlake.definitions.aggregate`) that registers query assets and the `GET /catalog` endpoint. A Processing Hub loads a new **SDC definitions** module (`pluginlake.definitions.sdc`) that registers SDC assets (small cell suppression, k-anonymity checks, aggregation functions) and the query dispatch + `POST /queries` endpoint. These are two separate Dagster code locations that are never loaded together on the same instance.
-
-   | Definitions module | Loaded on | Assets | API endpoints |
-   |---|---|---|---|
-   | `pluginlake.definitions.omop` | Datastation | `omop_raw_clinical_tables`, `omop_clinical_tables`, `omop_vocabulary_tables` | Existing ingestion endpoints |
-   | `pluginlake.definitions.fhir` | Datastation | `fhir_raw_tables`, `fhir_to_omop_tables` | Existing ingestion endpoints |
-   | `pluginlake.definitions.aggregate` (new) | Datastation | Predefined query assets (e.g. `count_per_group`, `cohort_summary`) | `GET /catalog`, `POST /execute` (query asset execution) |
-   | `pluginlake.definitions.sdc` (new) | Processing Hub | SDC assets (`small_cell_suppression`, `k_anonymity_check`, aggregation functions) | `POST /queries` (dispatch), `GET /catalog` (merged from datastations) |
-
-2. **Nuts credentials:** which `NutsAuthorizationCredential` VCs the node holds and which `purposeOfUse` values those credentials grant. A datastation issues credentials to a Processing Hub's DID, granting access to specific tables, filters, and time periods. A Processing Hub receives these credentials and uses them to obtain OAuth2 tokens for query dispatch. The credentials define the access boundary — a Processing Hub can only query what the credential explicitly allows.
-
-3. **Data connections:** whether the node has a local DuckLake with patient data (datastation) or operates without local data (Processing Hub). A datastation has `pluginlake.core.ducklake` configured with OMOP schemas and FHIR data. A Processing Hub has no DuckLake or an empty one used only as temporary scratch space for SDC processing (no persistent patient data).
-
-None of these are enforced by Nuts itself. Nuts provides the bilateral trust layer (DIDs, credentials, tokens). The role enforcement happens in pluginlake: the gateway checks the configured role against the `purposeOfUse` in incoming/outgoing requests, and the Dagster definitions determine which assets are available to execute.
-
-### Federation topologies
-
-The Nuts credential model allows several network configurations. Not all are equally safe.
-
-#### One Processing Hub, many datastations (standard federation)
-
-This is the primary model. One Processing Hub (e.g. IKNL oncology) receives `NutsAuthorizationCredential`s from participating hospitals. Each credential is bilateral and scoped. The Processing Hub aggregates results and applies SDC.
-
-```
-  Hosp. A ──credential──► Processing Hub (IKNL oncology) ◄──credential── Hosp. B
-                                ▲
-                                │
-                           credential
-                                │
-                            Hosp. C
-```
-
-#### One Processing Hub, multiple federations (multi-scope)
-
-A single Processing Hub DID can receive credentials with different data scopes, effectively hosting multiple logical federations on the same infrastructure. IKNL could run both an oncology federation (credentials scoped to cancer tables from 30 hospitals) and a rare disease federation (credentials scoped to different tables from 12 hospitals).
-
-The Processing Hub distinguishes federations by the credential's data scope. SDC is applied per federation: results from the oncology federation are never mixed with rare disease results.
-
-This works because credentials are bilateral and self-describing. The Processing Hub does not need separate configuration per federation — it derives the structure from the credentials it holds.
-
-#### Multiple Processing Hubs in the network (distinct purpose)
-
-Multiple Processing Hubs can coexist in the PLUGIN network, each serving a different analytical purpose. IKNL runs an oncology Processing Hub, DHD runs a quality indicators Processing Hub, a university runs a study-specific Processing Hub. Hospitals issue credentials to whichever Processing Hubs they participate with.
-
-This is the many-to-many topology already described: each Processing Hub is independent, each hospital decides independently which Processing Hubs to trust.
-
-#### Multiple Processing Hubs for the same data (dangerous)
-
-If two Processing Hubs both receive credentials for the same tables from the same hospitals, both see the raw aggregate results independently. A data user with access to both Processing Hubs could cross-reference suppressed cells between the two outputs and reconstruct data that SDC was designed to hide.
-
-Example: Processing Hub-A suppresses a group of 3 patients. Processing Hub-B, running a slightly different query on the same data, returns a group that includes those 3 patients in a larger bucket. Combining both outputs reveals the hidden group.
-
-Nuts does not prevent this — credentials are bilateral, and a hospital can issue identical scopes to multiple Processing Hubs. This must be a governance rule: a hospital should not issue overlapping data-scope credentials to multiple Processing Hubs unless the SDC implications are explicitly accepted.
-
-> **-> User can only be assigned to one processing hub per permit (federation agreement) !! **
-
-#### No Processing Hub (not supported)
-
-A federation without a Processing Hub is not possible in the PLUGIN model. The Processing Hub has three structural responsibilities that cannot be distributed:
-
-1. **Aggregation:** individual datastation results must be combined before they reach the data user.
-2. **SDC enforcement:** small cell suppression must be applied to the *combined* result, not to individual hospital results (a group of 2 at Hospital A and 3 at Hospital B is a group of 5 in total — safe to release, but suppressed if each hospital applied SDC independently).
-3. **Access gateway:** data users connect to the Processing Hub, never directly to datastations. The Processing Hub handles Nuts token acquisition on their behalf.
-
-Without a Processing Hub, each datastation would need to apply SDC on its own results (losing cross-hospital group size information), or data users would need direct Nuts-authenticated access to each datastation (losing the single access point and audit trail).
-
-A peer-to-peer model without a Processing Hub is architecturally different and not what PLUGIN proposes.
-
-| Topology | Valid | SDC safe | Notes |
-|---|---|---|---|
-| 1 Processing Hub, many datastations | Yes | Yes | Standard federation |
-| 1 Processing Hub, multiple data scopes | Yes | Yes | Separate SDC per scope |
-| Multiple Processing Hubs, distinct federations | Yes | Yes | Each Processing Hub independent |
-| Multiple Processing Hubs, overlapping data scopes | Technically possible | No | Governance must prevent |
-| No Processing Hub | No | N/A | Contradicts PLUGIN model |
-
-### Bolt specification and credential scopes
-
-A Bolt is a protocol specification that defines the rules for inter-station communication.
-pluginlake defines one Bolt (`pluginlake-federation`) that describes:
-
-- The allowed `purposeOfUse` values:
-  - `pluginlake-query-dispatch` (Processing Hub→datastation): the Processing Hub dispatches a query to a datastation for execution.
-  - `pluginlake-data-serve` (datastation→Processing Hub): the datastation returns results to the Processing Hub.
-  - `pluginlake-query-access` (consumer org→Processing Hub): a data user's organization accesses the Processing Hub to submit queries and view results.
-- The credential types required per purpose.
-- The API endpoints each purpose may call.
-
-This means the Bolt defines three cross-organizational boundaries, each with its own credential type:
-
-| Boundary | Credential issuer | Credential subject | purposeOfUse | What it grants |
-|---|---|---|---|---|
-| Datastation → Processing Hub | Datastation | Processing Hub's DID | `pluginlake-query-dispatch` | Processing Hub may query specific tables, filters, time period |
-| Processing Hub → consumer org | Processing Hub | Consumer org's DID | `pluginlake-query-access` | Org's users may submit queries and view results on this Processing Hub |
-
-The Processing Hub issues `pluginlake-query-access` credentials to consumer organizations. This is the reverse direction of data access credentials: datastations grant data access *to* the Processing Hub, and the Processing Hub grants query access *to* consumer organizations. A consumer organization without this credential cannot obtain access tokens for the Processing Hub.
-
-Every station runs the same Bolt. Actual collaborations are `NutsAuthorizationCredential` VCs. Each credential encodes:
-
-- The requesting organization's DID (the Processing Hub).
-- A data scope: which tables, column filters, and time period the Processing Hub may query.
-- The `purposeOfUse` (must match the Bolt).
-- The validity period.
-
-| Layer | What it contains | Scope | Visibility |
-|---|---|---|---|
-| Bolt specification | Protocol rules, allowed purposes, required credentials | Network-wide | Public (same for all stations) |
-| `NutsAuthorizationCredential` | One collaboration: Processing Hub↔datastation, with data scope | Bilateral | Private (only issuer + subject) |
-
-Credentials can also contain computation scopes (which query assets or algorithm types are permitted), enabling future algorithm governance.
-
-### Query execution model
-
-Queries are never raw SQL. Every query is a predefined Dagster asset on the datastation.
-
-1. A data user submits a query via the Processing Hub (UI or Python client). The Processing Hub verifies the user's identity and organizational DID (see Data user authentication). The Processing Hub checks that the user's organization holds a `pluginlake-query-access` credential for this Processing Hub.
-2. The Processing Hub validates query parameters against a Pydantic schema.
-3. For each relevant datastation, the Processing Hub's Nuts Node obtains an OAuth2 token using the `NutsAuthorizationCredential`.
-4. The Processing Hub dispatches the query asset call to each datastation with the Nuts JWT.
-5. Each datastation's middleware validates the token, checks the credential scope and `purposeOfUse`, and executes the Dagster asset locally.
-6. Results are returned to the Processing Hub. The Processing Hub applies SDC assets (e.g. small cell suppression for groups < k).
-7. Only the SDC-processed output reaches the data user. Raw results are not stored on the Processing Hub.
-
-Each datastation publishes a catalog of available query assets (`GET /catalog`), so the Processing Hub and data users know what is available per collaboration.
-
-#### Partial failure handling
-
-When the Processing Hub dispatches a query to multiple datastations, some may fail or time out.
-The architectural policy: **SDC correctness is only guaranteed on complete results.** If some datastations fail, the Processing Hub returns a partial result with a manifest (which datastations contributed, which failed). The data user decides whether the partial result is usable. The Processing Hub never silently drops failed datastations.
-
-#### Operational concerns
-
-The following topics are architecturally relevant but are implementation-level concerns addressed in [E6: Operationele hardening en schaalbaarheid](https://github.com/plugin-healthcare/pluginlake/issues/78):
-
-- **Async query dispatch and result polling:** Dagster runs are async. The Processing Hub dispatches, receives a `query_id`, and polls for results. Result TTL and expiry handling are required.
-- **Versioning and catalog compatibility:** the catalog includes schema versions per asset. The Processing Hub checks compatibility before dispatching.
-- **Nuts Node availability:** hard dependency. No graceful degradation (token caching would accept revoked credentials). Operational monitoring required.
-- **Rate limiting and backpressure:** datastations enforce per-Processing Hub DID rate limits at the gateway level (not Dagster-level). `429 Too Many Requests` with backoff.
-
-### Deployment
-
-Each station's Docker Compose adds a Nuts Node sidecar:
+Docker Compose configuration:
 
 ```yaml
 services:
@@ -339,8 +80,8 @@ services:
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     ports:
-      - "1323:1323" # internal API (localhost only)
-      - "5555:5555" # gRPC (public, mTLS)
+      - "1323:1323"  # internal API (localhost only)
+      - "5555:5555"  # gRPC (public, mTLS)
     volumes:
       - "./config/nuts/nuts.yaml:/opt/nuts/nuts.yaml:ro"
       - "./config/nuts/certificate.pem:/opt/nuts/certificate.pem:ro"
@@ -349,129 +90,279 @@ services:
       - "nuts-data:/opt/nuts/data"
 ```
 
+### Middleware integration
+
+The FastAPI middleware validates incoming inter-node requests:
+
+1. Extract the access token from the `Authorization` header.
+2. Validate via `POST /internal/auth/v2/dpop/validate` on the local Nuts Node (localhost, no network round-trip).
+3. Populate the request context with the authenticated organizational identity (`organization_did`, `organization_name`).
+4. The existing `require_role`/`require_auth` dependencies in `security.py` use this context for route-level authorization.
+
+The middleware activates for any cross-organizational call (hub→station, station→hub). For purely local admin requests (CLI on the same machine), a local API key may be used.
+
+### DID-per-instance model
+
+Each pluginlake instance gets its own DID (a cryptographic keypair). A `NutsOrganizationCredential` is issued to each DID, tying it to a real-world organization.
+
+```mermaid
+graph TD
+    subgraph "Hospital A (single organization)"
+        SA[Station A<br/>DID: did:nuts:stationA<br/>NutsOrgCred: Hospital A]
+        HA[Hub A<br/>DID: did:nuts:hubA<br/>NutsOrgCred: Hospital A]
+    end
+    subgraph "Hospital B"
+        SB[Station B<br/>DID: did:nuts:stationB<br/>NutsOrgCred: Hospital B]
+    end
+    subgraph "Collab X-Y (joint hub)"
+        HC[Hub C<br/>DID: did:nuts:hubC<br/>NutsOrgCred: Consortium X-Y]
+    end
+    HA --> SB
+    HC --> SA
+    HC --> SB
+```
+
+Key properties:
+
+- An organization running both a station and a hub has two DIDs, two Nuts nodes, but both credentials identify the same organization.
+- External parties see two distinct network participants with the same organizational identity but different roles and endpoints.
+- For **collaboration hubs** operated jointly by multiple organizations, the `NutsOrganizationCredential` must be issued to a named entity (foundation, consortium, or designated operator). This is a governance decision per collaboration.
+
+### Network membership via Discovery Service (RFC022)
+
+DHD hosts a Nuts Discovery Service server for the pluginlake network. Every hub and station registers by presenting a Verifiable Presentation containing their `NutsOrganizationCredential`. This solves:
+
+- **"How does a new station join?"** — register at the discovery service.
+- **"How do nodes find each other?"** — query the discovery service for other nodes and their DSP endpoints.
+- **Network membership gate** — only nodes with a valid `NutsOrganizationCredential` can register.
+
+The discovery server is a Nuts node with server mode enabled, not a separate infrastructure component. Only one is needed for the entire pluginlake network. Registration parameters include the `authServerURL` automatically.
+
+---
+
+## Researcher identity scoping
+
+A researcher's identity is scoped to a processing hub. Each hub issues its own independent credentials and permits. There is no cross-hub identity correlation or credential sharing.
+
+This means:
+
+- A researcher authenticates at one processing hub and receives credentials (VCs) from that hub.
+- If a researcher needs access to a different hub, that is a separate relationship with separate credentials.
+- SDC checking stays within a single hub's domain (the hub tracks all queries from its researchers across all its collaborations).
+
+This keeps the model simple and prevents SDC bypass through cross-hub query combination.
+
+---
+
+## Node roles
+
+Every node in the network runs the same pluginlake software. What a node does is determined by its configuration.
+
+| Aspect | Data station | Processing hub |
+|---|---|---|
+| Local data | Yes (DuckLake, OMOP CDM, FHIR) | No (data ingestion disabled) |
+| Dagster assets | Query execution on local data | SDC, aggregation, dispatch |
+| Nuts Node | Yes (own DID) | Yes (own DID) |
+| Receives requests from | Processing hub (via Nuts VP) | Researchers (via OIDC + VC) |
+
+A pluginlake configuration option (`role: hub` or `role: station`) activates the correct modules. The gateway enforces this role by checking the request context.
+
+There is no separate processing hub codebase. Adding a processing hub to the network is deploying another pluginlake instance with a different config profile and its own Nuts Node.
+
+### Dagster definitions per role
+
+| Definitions module | Loaded on | Purpose |
+|---|---|---|
+| `pluginlake.definitions.omop` | Station | OMOP data ingestion assets |
+| `pluginlake.definitions.fhir` | Station | FHIR data ingestion assets |
+| `pluginlake.definitions.aggregate` (new) | Station | Predefined query assets, `GET /catalog`, `POST /execute` |
+| `pluginlake.definitions.sdc` (new) | Hub | SDC assets, query dispatch, `POST /queries` |
+
+These are two separate Dagster code locations, deployed on separate instances in production. Colocation on a single instance is acceptable for dev/test only (see open question §1 below).
+
+---
+
+## Federation topologies and SDC safety
+
+### One hub, many stations (standard federation)
+
+The primary model. One processing hub receives bilateral agreements (via DSP, see ADR-007) from participating hospitals. The hub aggregates results and applies SDC.
+
+```
+Hosp. A ──agreement──► Hub (IKNL oncology) ◄──agreement── Hosp. B
+                              ▲
+                              │
+                         agreement
+                              │
+                          Hosp. C
+```
+
+### One hub, multiple federations (multi-scope)
+
+A single hub can host multiple logical federations with different data scopes. IKNL could run both an oncology federation (30 hospitals, cancer tables) and a rare disease federation (12 hospitals, different tables). SDC is applied per federation; results are never mixed.
+
+### Multiple hubs, distinct purpose
+
+Multiple hubs coexist (IKNL for oncology, DHD for quality indicators, a university for a study). Each is independent. Hospitals decide which hubs to trust.
+
+### Multiple hubs, overlapping data (dangerous)
+
+If two hubs both have agreements for the same tables from the same hospitals, a researcher with access to both could cross-reference suppressed cells to reconstruct hidden data.
+
+**Governance rule:** A researcher's identity is scoped to a single hub. Since each hub issues its own credentials independently, there is no mechanism for a researcher to combine results across hubs using the same identity. Hospitals should avoid issuing overlapping-scope agreements to multiple hubs unless SDC implications are explicitly accepted.
+
+### No hub (not supported)
+
+The PLUGIN model requires a processing hub for three structural reasons:
+
+1. **Aggregation** — individual station results must be combined before reaching the researcher.
+2. **SDC enforcement** — small cell suppression must be applied to combined results (a group of 2 at Hospital A + 3 at Hospital B = 5 total, safe to release).
+3. **Access gateway** — researchers connect to the hub, never directly to stations.
+
+| Topology | Valid | SDC safe | Notes |
+|---|---|---|---|
+| 1 hub, many stations | Yes | Yes | Standard federation |
+| 1 hub, multiple scopes | Yes | Yes | Separate SDC per scope |
+| Multiple hubs, distinct federations | Yes | Yes | Each hub independent |
+| Multiple hubs, overlapping scopes | Technically possible | No | Governance must prevent |
+| No hub | No | N/A | Contradicts PLUGIN model |
+
+---
+
+## Bolt definition
+
+pluginlake defines one Bolt (`pluginlake-data-access`) for the Nuts network:
+
+- **Scope:** `pluginlake-data-access`
+- **Required credential:** `NutsOrganizationCredential`
+- **Category:** server-to-server, Organization (RFC003 §7)
+- **No patient subject, no user context in the Nuts layer**
+
+The Bolt establishes that any node presenting a valid `NutsOrganizationCredential` is a recognized participant in the pluginlake network. It does NOT carry per-user permissions or data access scopes (those are handled by DSP agreements and ODRL VCs in ADR-007).
+
+**Network role enforcement:** The `NutsOrganizationCredential` includes a `role` claim (`hub` or `station`). The station's Bolt policy validates that the requesting node holds `role: hub` — stations cannot initiate data requests to other stations. This is the first protection layer (boundary 2 in ADR-007) that rejects wrong-role requests before DSP/ODRL logic runs.
+
+The Bolt is deployed as a JSON policy file per Nuts node, shipped as a default in the pluginlake repository.
+
+---
+
+## Nuts constraints and design considerations
+
+### One Nuts node per pluginlake instance
+
+The Nuts node is not multi-tenant. Each pluginlake instance runs its own Nuts node with its own DID. An organization running both a station and a hub runs two Nuts nodes with separate DIDs but the same `NutsOrganizationCredential` organizational identity.
+
+### Scope granularity
+
+Nuts scopes map to static presentation definitions, not individual resources. Per-dataset access control is not achievable at the Nuts layer. This is by design: Nuts handles organizational membership, the VC-based ODRL profile (ADR-007) handles fine-grained per-user access.
+
+### Credential model and FHIR
+
+RFC014's `resources` array uses FHIR operation names, and the abstract says "currently only usable for FHIR based services." However, the current Nuts node stable implementation uses scope-to-presentation-definition mapping with no FHIR dependency. For server-to-server flows without a patient subject, only `purposeOfUse` is needed. The FHIR association is convention, not a technical constraint.
+
+### `localParameters` limitations
+
+RFC014 `localParameters` cannot be used as a general-purpose permission carrier: parameters may not influence the credential subject, a Bolt may not require them, and they are of value only to the issuer. Fine-grained permissions belong in the PluginlakeAccessCredential (VC with ODRL profile, ADR-007), not in Nuts credentials.
+
+### DPoP validation
+
+The Nuts node provides `POST /internal/auth/v2/dpop/validate` for DPoP proof validation on every request. This adds a synchronous call per authenticated request and makes the Nuts node a high-availability dependency.
+
+### Nuts Node availability
+
+The Nuts Node is a hard dependency for inter-node auth. No graceful degradation (token caching would accept revoked credentials). Operational monitoring must ensure availability.
+
+---
+
+## Data user authentication
+
+### How Nuts handles identity
+
+Nuts operates at the **organization level**. Each DID represents a care organization, not an individual user.
+
+User identity is a separate layer built into the Nuts OAuth2 flow. When a user acts on behalf of an organization, they sign a contract (a VP). Nuts supports two mechanisms:
+
+- **Employee Identity:** the organization's system vouches for the user (identifier, name, role).
+- **IRMA:** the user proves identity via the IRMA app using citizen credentials.
+
+The resulting JWT carries both organizational identity and user identity. When the receiving party introspects the token, it sees `username`, `initials`, `family_name`, `assurance_level`, plus the organization's DID.
+
+### Authentication flow for researchers
+
+For pluginlake, the primary approach is **institutional OIDC** (SURFconext, Entra ID) with DID binding:
+
+1. Researcher logs in via institutional SSO at the processing hub.
+2. The hub maps the OIDC issuer to a known Nuts DID (verified mapping).
+3. The hub issues a PluginlakeAccessCredential (VC) to the researcher (see ADR-007).
+4. For hub→station communication, the hub uses its own Nuts identity (org-to-org).
+
+The alternative Nuts-native flow (PractitionerLogin contract) is available for organizations that prefer it. Both approaches produce the same result: verified organizational identity + user identity.
+
+### Multi-tenancy consideration
+
+The Nuts Node is explicitly not multi-tenant. If a processing hub serves users from multiple organizations, user authentication is handled at the OIDC/application layer, not at the Nuts layer. The hub's Nuts node has a single DID representing the hub operator.
+
+---
+
 ## Alternatives considered
 
 | Alternative | Why not chosen |
 |---|---|
-| Centralized OAuth2 (Keycloak, Entra ID) | Contradicts federated model: single identity provider = single point of failure and political barrier. |
-| Mutual TLS only | Authenticates the machine, not the user or purpose. Cannot express per-patient, per-purpose authorization. |
+| Centralized OAuth2 (Keycloak, Entra ID) | Contradicts federated model: single point of failure and political barrier. |
+| Mutual TLS only | Authenticates the machine, not the organization or purpose. |
 | Custom token exchange protocol | Duplicates what Nuts provides, without the Dutch healthcare ecosystem. |
-| Direct Nuts Node API exposure | Bypasses the gateway, losing centralized logging, rate limiting, and composability with local auth (ADR-005). |
+| Direct Nuts Node API exposure | Bypasses the gateway, losing logging, rate limiting, composability (ADR-005). |
+
+---
 
 ## Consequences
 
-- Every node runs the same pluginlake software. Role (Processing Hub or datastation) is determined by which Dagster definitions modules are loaded, which Nuts credentials the node holds, and which data connections are configured.
-- Two new Dagster definitions modules will be added: `pluginlake.definitions.aggregate` (datastation: query assets, catalog) and `pluginlake.definitions.sdc` (Processing Hub: SDC assets, query dispatch, aggregation functions).
-- Each node must run a Nuts Node sidecar (~200 MB memory, negligible Processing Hub at rest) with its own DID.
+- Each node runs a Nuts Node sidecar (~200 MB memory) with its own DID.
 - Station operators need PKIoverheid certificates for the production network.
-- A `pluginlake-federation` Bolt specification defines three `purposeOfUse` values: `pluginlake-query-dispatch` (Processing Hub→datastation), `pluginlake-data-serve` (datastation→Processing Hub), `pluginlake-query-access` (consumer org→Processing Hub).
-- Collaboration contracts are `NutsAuthorizationCredential` VCs on the Nuts DAG, encoding data scopes (tables, filters, time period) and distributed privately.
-- Consumer organizations receive `pluginlake-query-access` credentials from the Processing Hub to access the federation.
-- The gateway enforces the configured role: it rejects `purposeOfUse` values that don't match the node's role.
-- Queries are always Dagster assets with Pydantic-validated parameters, never raw SQL.
-- The Processing Hub applies SDC assets on combined results. Raw data never leaves the datastation; raw intermediate results are not stored on the Processing Hub.
-- Partial query failures are handled transparently: the response includes a manifest of which datastations contributed and which failed.
-- Operational concerns (async dispatch, versioning, rate limiting, monitoring) are addressed in [E6: Operationele hardening en schaalbaarheid](https://github.com/plugin-healthcare/pluginlake/issues/78).
-- The Nuts Node sidecar is a hard dependency for inter-station auth. No graceful degradation; operational monitoring must ensure availability.
-- The FastAPI middleware gains a dependency on the local Nuts Node for token introspection.
+- The FastAPI middleware gains a dependency on the local Nuts Node for DPoP validation.
+- Nuts handles organizational identity only. Per-user authorization is handled by DSP + ODRL VCs (ADR-007).
+- A researcher's identity is scoped to a single processing hub. No cross-hub credential sharing.
+- The pluginlake Bolt (`pluginlake-data-access`) requires only `NutsOrganizationCredential`, no fine-grained scopes.
+- Network discovery is via DHD's Discovery Service server. Joining the network = registering there.
 - Each station enforces rules locally; no central policy engine. A compromised node cannot forge credentials issued by others.
-- All cross-organizational auth (user→Processing Hub and Processing Hub→datastation) is tied to Nuts organizational identity. Local admin access (CLI) may use API keys.
-- Data users access the network exclusively through the Processing Hub. The Processing Hub verifies their organizational identity and handles Nuts token acquisition on their behalf.
+- Local admin access (CLI) may use API keys (no Nuts needed for same-machine access).
+
+---
 
 ## Open governance questions
 
-The following questions require stakeholder decisions before production deployment.
+### 1. Can a hub and station share the same instance?
 
-### 1. Can a Processing Hub and datastation share the same instance?
+Technically possible (two Nuts nodes, two Dagster asset groups, one gateway). Carries colocation risks (container escape, misconfiguration, audit ambiguity). Recommendation: separate instances for production, colocation acceptable for dev/test.
 
-It is technically possible to run both roles on the same machine: two separate Nuts Nodes (each with its own DID), two Dagster asset groups (query assets + SDC assets), one shared pluginlake gateway that routes based on which DID the request targets.
-The credentials remain cryptographically separate.
+### 2. Credential lifetime and renewal
 
-However, colocation carries risks:
-
-| Concern | Separate instances | Colocated on same machine |
-|---|---|---|
-| Container escape / OS-level vulnerability | One role compromised, other isolated | Both roles compromised simultaneously |
-| Ops mistakes (wrong env var, shared volume) | Cannot accidentally cross-link | Risk of misconfiguration leaking data between roles |
-| Incident response ("which DID was compromised?") | Clear: one host = one role | Ambiguous: must determine which DID was affected |
-| Audit trail (NEN 7513) | Clean: each instance has one purpose | Must distinguish two audit streams on one machine |
-| SDC integrity | Processing Hub has no local data by definition | Processing Hub process runs alongside local patient data |
-| Infrastructure cost | Two deployments per hospital | One deployment, lower cost |
-
-**Engineering recommendation:** for development and testing, colocation is fine.
-For production healthcare deployments, separate instances is the safer default.
-This decision should be made by the security architect and data protection officer based on the hospital's risk appetite and NEN 7510 ISMS.
-
-### 2. Who approves new collaborations?
-
-A collaboration starts when a datastation issues a `NutsAuthorizationCredential` to a Processing Hub's DID.
-Nuts does not require any approval workflow: issuing a credential is a single API call.
-
-The question: who within a hospital is authorized to issue that credential?
-Options include the data protection officer, a research committee, or a designated data steward.
-pluginlake needs to define whether credential issuance goes through an approval flow in the UI or is a direct administrative action.
-
-### 3. What are the SDC thresholds?
-
-The Processing Hub applies statistical disclosure control (SDC) on combined query results before they reach the data user.
-The key parameter is the minimum group size *k* for small cell suppression: groups smaller than *k* are masked.
-
-Who decides the value of *k*? Options:
-
-- A network-wide default (e.g. k=5).
-- A per-collaboration setting encoded in the credential.
-- Configurable per query by the data user, within bounds set by the credential.
-
-A higher *k* is safer but reduces analytical utility.
-
-### 4. Credential lifetime and renewal
-
-Each `NutsAuthorizationCredential` has a validity period. Questions to resolve:
-
-- What is the default validity period? (e.g. 1 year, duration of a study, indefinite until revoked)
-- Is there automatic renewal, or must each credential be manually reissued?
-- What happens to in-flight queries when a credential expires?
+- Default validity period for organizational credentials?
+- Automatic renewal vs manual reissuance?
 - Who monitors upcoming expirations?
 
-### 5. Algorithm and query governance
+### 3. Collaboration hub identity
 
-Datastations expose predefined query assets via their catalog. As the network matures:
+For joint hubs operated by multiple organizations, who issues the `NutsOrganizationCredential`? Options: formal legal entity, designated operator, or DHD as network operator.
 
-- Who decides which query assets a datastation offers?
-- Can a Processing Hub request custom query assets, or only use what is in the catalog?
-- Should the credential contain a computation scope that restricts which asset types are permitted?
-- Is there an approval process for adding new query types to the network?
+### 4. Data user authentication mechanism
 
-### 6. Data user authentication mechanism
+Start with OIDC + DID mapping for researchers (standard SSO UX). Nuts PractitionerLogin available for organizations that prefer it. Decision: which mechanism is default for the pluginlake UI?
 
-The Processing Hub must verify that a data user belongs to a specific organization in the Nuts network.
-Nuts natively supports this through the `PractitionerLogin` / `BehandelaarLogin` contract flow: the user signs a contract at their own organization's Nuts Node, and the resulting access token carries both org DID and user identity.
-
-However, this requires every consuming organization to run a Nuts Node.
-For organizations that already participate as datastations this is no extra cost.
-For external research institutions without healthcare infrastructure, it may be a barrier.
-
-The alternative is federated OIDC (SURFconext, Entra ID) with a verified mapping from OIDC issuer to Nuts DID.
-
-| Approach | How it works | Pros | Cons |
-|---|---|---|---|
-| Nuts contract flow (recommended) | User signs `PractitionerLogin` at their org's Nuts Node → access token carries org DID + user identity → Processing Hub introspects | Fully consistent with all other boundaries; no separate identity system; org identity cryptographically proven; user identity in audit trail | Every consuming org needs a Nuts Node; contract signing UX (employee identity or IRMA) must be integrated in the pluginlake UI |
-| Federated OIDC + DID mapping | User logs in via institutional SSO → Processing Hub maps OIDC issuer claim to a Nuts DID → org identity derived from mapping | Standard SSO experience; no Nuts awareness needed by the user | Requires maintaining a trusted OIDC-to-DID mapping; mapping correctness is an operational risk; two identity systems to maintain |
-
-**Engineering recommendation:** start with the Nuts contract flow for organizations that already have a Nuts Node (which is all datastations and Processing Hub operators).
-Consider OIDC as a future extension for external academic users if the Nuts Node requirement proves to be an adoption barrier.
-Both approaches produce the same request context (user + verified org DID), so downstream logic is identical.
+---
 
 ## Related documents
 
-- [ADR-001: Asset Architecture](adr-001-asset-architecture.md): Dagster definitions and `Definitions.merge()` pattern
-- [ADR-005: FastAPI Gateway](adr-005-fastapi-gateway.md): the gateway that Nuts middleware integrates into
+- [ADR-001: Asset Architecture](adr-001-asset-architecture.md) — Dagster definitions and `Definitions.merge()` pattern
+- [ADR-005: FastAPI Gateway](adr-005-fastapi-gateway.md) — the gateway that Nuts middleware integrates into
+- [ADR-007: DSP + Authorization](adr-007-dataspace-protocol-authz-authc-rbac.md) — contract negotiation, per-user VCs, enforcement (trust boundary 3)
 
 ## References
 
 - [Nuts Node documentation (v5.4)](https://nuts-node.readthedocs.io/en/v5.4/)
-- [Nuts authentication guide](https://nuts-node.readthedocs.io/en/v5.4/pages/getting-started/5-authentication.html)
-- [Nuts authorization guide](https://nuts-node.readthedocs.io/en/v5.4/pages/getting-started/6-adding-authorizations.html)
+- [Nuts Discovery Service (RFC022)](https://nuts-foundation.gitbook.io/drafts/rfc/rfc022-discovery)
+- [Nuts authentication (RFC003)](https://nuts-foundation.gitbook.io/drafts/rfc/rfc003-oauth2-authorization)
+- [Nuts authorization credentials (RFC014)](https://nuts-foundation.gitbook.io/drafts/rfc/rfc014-authorization-credential)
 - [Nuts security model](https://nuts-node.readthedocs.io/en/v5.4/pages/technology/security_model.html)
 - [W3C DIDs](https://www.w3.org/TR/did-core/)
 - [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/)

--- a/docs/decisions/adr-007-dataspace-protocol-authz-authc-rbac.md
+++ b/docs/decisions/adr-007-dataspace-protocol-authz-authc-rbac.md
@@ -50,7 +50,7 @@ Per-request calls carry two layers: the Nuts DPoP-bound access token in the `Aut
 |---|---|
 | **DID** (Decentralized Identifier) | A globally unique identifier (like a URL) that an organization controls itself — no central registry needed. Each pluginlake instance has its own DID. |
 | **Credential** | A digitally signed statement about a subject. Example: "Hospital X is a recognized PLUGIN participant with role station." |
-| **Verifiable Credential (VC)** | A credential in a standard format (W3C) that anyone can verify without calling the issuer. Contains claims, a subject, an issuer, and a cryptographic signature. |
+| **Verifiable Credential (VC)** | A credential in a standard format (W3C) that anyone can verify without calling the issuer. Contains claims, a subject, an issuer, and a cryptographic signature. In pluginlake, a VC is the *container* that carries permissions from hub to station. |
 | **Verifiable Presentation (VP)** | A wrapper that a holder uses to present one or more VCs to a verifier. The VP proves the holder actually controls the credential (not just copied it). |
 | **Signature** | Cryptographic proof that a credential was issued by a specific DID and has not been tampered with. Verifiers check the signature against the issuer's public key. |
 | **OIDC** (OpenID Connect) | Standard protocol for "log in with your institution." Handles usernames, passwords, MFA — the normal login experience. Used at boundary 1 only. |
@@ -58,12 +58,11 @@ Per-request calls carry two layers: the Nuts DPoP-bound access token in the `Aut
 | **DSP** (Dataspace Protocol) | Eclipse standard for how two organizations negotiate data access. Defines catalog browsing, contract negotiation, and data transfer as HTTP message exchanges. |
 | **ODRL** (Open Digital Rights Language) | A W3C standard for expressing permissions and constraints ("user X may read columns A,B of dataset Y where region=NL"). Used inside VCs for boundary 3. |
 | **Contract / Agreement** | The result of a successful DSP negotiation. Both parties store a copy. It defines what is allowed in principle — individual requests are still verified against it. |
-| **Verifiable Credential (VC)** | A credential in a standard format (W3C) that anyone can verify without calling the issuer. Contains claims, a subject, an issuer, and a cryptographic signature. In pluginlake, a VC is the *container* that carries permissions from hub to station. |
 | **Permission** (ODRL) | A specific rule inside a VC that says "user X may perform action Y on asset Z subject to constraints." The atomic unit of authorization at boundary 3. |
-
-**How they relate:** A DSP contract sets the outer bounds ("hub and station agree to collaborate"). The hub then issues VCs to its researchers — each VC contains one or more ODRL permissions scoped within the contract's bounds. The station verifies the VC signature and evaluates each permission against the request.
 | **DPoP** (Demonstration of Proof-of-Possession) | A mechanism that binds an access token to a specific key pair, preventing token theft. Each request includes a fresh proof that the caller holds the private key. |
 | **Bolt** | A Nuts "use case definition" — a configuration that says which credentials are required for a specific interaction pattern (e.g. pluginlake data access). |
+
+**How they relate:** A DSP contract sets the outer bounds ("hub and station agree to collaborate"). The hub then issues VCs to its researchers — each VC contains one or more ODRL permissions scoped within the contract's bounds. The station verifies the VC signature and evaluates each permission against the request.
 
 ### pluginlake-specific terms
 
@@ -180,13 +179,24 @@ Five options were evaluated. The adopted architecture is a VC-native ODRL approa
 ## Consequences
 
 - pluginlake gains a DSP-compliant external surface aligned with Health-RI and EHDS
-- Every station runs three sidecars: Nuts node, PostgresQL server and Dagster code server. OPA is not required.
+- Every station runs three sidecars: Nuts node, PostgreSQL server and Dagster code server. OPA is not required.
 - The pluginlake ODRL profile (credential schema + actions + constraint types) is the highest priority deliverable
 - Hub signing key distribution must be resolved (DID document, DSP negotiation, or discovery parameters)
 - Station asset registry and operation registry must be defined per station (YAML config)
 - Collaboration hubs need a governance decision on organizational identity before deployment
 - New modules required: `src/pluginlake/authz/` and `src/pluginlake/dsp/`
 - Streamlit UI gets new pages: credential management (central) and access control (datastation)
+
+---
+
+## Security invariants
+
+These hold across all phases, including the placeholder middleware used while station internals are built first:
+
+- **Single enforcement point (PEP):** No request reaches station compute (Dagster, DuckLake, PostgreSQL) except through one mandatory authn/authz enforcer. Every route, including `POST /api/assets/{key}/materialize`, catalog routes and any local admin path, passes through it. No request is served without authn/authz.
+- **Network perimeter:** The station cluster and its services are isolated from outside contact. Only curated, explicitly exposed endpoints are reachable. Internal services (Nuts node, PostgreSQL, Dagster) are never directly accessible from outside the wall.
+- **Transport independence:** If FastAPI is later replaced by a leaner protocol or service mesh, enforcement stays in the proxy or sidecar so no transport can bypass the PEP.
+- **Layer separation:** Nuts governs machine-to-machine network membership and coarse machine roles (hub, analytics, ml) only. Fine-grained, user-based, contract-scoped access lives in the separate authz layer on top, because Nuts does not provide that granularity.
 
 ---
 
@@ -233,3 +243,4 @@ Five options were evaluated. The adopted architecture is a VC-native ODRL approa
 15. Credential validity duration (start with 24-hour VCs)
 16. Processing hub specification alignment (contribute to Health-RI §4.4)
 17. Processing hub DSP client implementation (Phase 2)
+18. **Service-to-service transport** — investigate replacing FastAPI with a leaner protocol or service mesh for internal node-to-node traffic, keeping enforcement in a proxy or sidecar so no transport bypasses the PEP.

--- a/docs/decisions/adr-007-dataspace-protocol-authz-authc-rbac.md
+++ b/docs/decisions/adr-007-dataspace-protocol-authz-authc-rbac.md
@@ -1,0 +1,235 @@
+# ADR-007: Dataspace Protocol, authentication, and authorization architecture for pluginlake
+
+**Status:** Proposed
+**Date:** 2026-05-28
+
+## TL;DR
+
+**What this ADR decides:**
+
+How pluginlake data stations and processing hubs authenticate, authorize, and exchange data in a federated multi-hospital network, compliant with EHDS, Health-RI, and the Eclipse Dataspace Protocol.
+
+**Key questions answered:**
+
+| Question | Decision |
+|---|---|
+| How do nodes identify each other? | **Nuts** (decentralized identity, org-level credentials via DIDs) |
+| How are data access terms negotiated? | **DSP contract negotiation** (bilateral, station must approve) |
+| How are per-user permissions expressed? | **Verifiable Credentials with ODRL profile** (issued by hub, verified by station) |
+| Who has final authority over data? | **Always the data station** (can deny/restrict regardless of credential claims) |
+| How are permissions enforced at query time? | **Built-in ODRL profile evaluator** (no OPA, no external policy engine) |
+| How do abstract permissions map to real data? | **Station-local asset + operation registry** (YAML config per station) |
+| What happens after a contract is agreed? | **Per-request VC presentation** (no re-negotiation needed per query) |
+
+**Architecture in one diagram:**
+
+```mermaid
+graph LR
+    R[Researcher] -->|OIDC login| HUB[Processing Hub]
+    HUB -->|issues VC with<br/>ODRL permissions| W[Nuts node wallet]
+    HUB -->|DSP negotiation<br/>via Nuts| STA[Data Station]
+    W -->|VC presented<br/>per request| STA
+    STA -->|verify VC + enforce<br/>local restrictions| DL[DuckLake / Dagster]
+```
+
+Per-request calls carry two layers: the Nuts DPoP-bound access token in the `Authorization` header (proves org identity, boundary 2) and the PluginlakeAccessCredential as a VP in the request body or a dedicated header (proves user permissions, boundary 3).
+
+**Delivery phases:**
+
+1. **Phase 1:** DSP routes + Nuts identity + contract negotiation (single hub ↔ single station)
+2. **Phase 2:** VC-based per-user credentials + ODRL evaluation + enforcement layer (multi-hub)
+3. **Phase 3:** Dashboards + RBAC + collaboration governance (production network)
+
+---
+
+## Terminology
+
+### General concepts
+
+| Term | What it is |
+|---|---|
+| **DID** (Decentralized Identifier) | A globally unique identifier (like a URL) that an organization controls itself — no central registry needed. Each pluginlake instance has its own DID. |
+| **Credential** | A digitally signed statement about a subject. Example: "Hospital X is a recognized PLUGIN participant with role station." |
+| **Verifiable Credential (VC)** | A credential in a standard format (W3C) that anyone can verify without calling the issuer. Contains claims, a subject, an issuer, and a cryptographic signature. |
+| **Verifiable Presentation (VP)** | A wrapper that a holder uses to present one or more VCs to a verifier. The VP proves the holder actually controls the credential (not just copied it). |
+| **Signature** | Cryptographic proof that a credential was issued by a specific DID and has not been tampered with. Verifiers check the signature against the issuer's public key. |
+| **OIDC** (OpenID Connect) | Standard protocol for "log in with your institution." Handles usernames, passwords, MFA — the normal login experience. Used at boundary 1 only. |
+| **Nuts** | Dutch healthcare identity network. Provides DID management, credential issuance, and VP exchange between organizations. Handles boundary 2 (org-to-org trust). |
+| **DSP** (Dataspace Protocol) | Eclipse standard for how two organizations negotiate data access. Defines catalog browsing, contract negotiation, and data transfer as HTTP message exchanges. |
+| **ODRL** (Open Digital Rights Language) | A W3C standard for expressing permissions and constraints ("user X may read columns A,B of dataset Y where region=NL"). Used inside VCs for boundary 3. |
+| **Contract / Agreement** | The result of a successful DSP negotiation. Both parties store a copy. It defines what is allowed in principle — individual requests are still verified against it. |
+| **Verifiable Credential (VC)** | A credential in a standard format (W3C) that anyone can verify without calling the issuer. Contains claims, a subject, an issuer, and a cryptographic signature. In pluginlake, a VC is the *container* that carries permissions from hub to station. |
+| **Permission** (ODRL) | A specific rule inside a VC that says "user X may perform action Y on asset Z subject to constraints." The atomic unit of authorization at boundary 3. |
+
+**How they relate:** A DSP contract sets the outer bounds ("hub and station agree to collaborate"). The hub then issues VCs to its researchers — each VC contains one or more ODRL permissions scoped within the contract's bounds. The station verifies the VC signature and evaluates each permission against the request.
+| **DPoP** (Demonstration of Proof-of-Possession) | A mechanism that binds an access token to a specific key pair, preventing token theft. Each request includes a fresh proof that the caller holds the private key. |
+| **Bolt** | A Nuts "use case definition" — a configuration that says which credentials are required for a specific interaction pattern (e.g. pluginlake data access). |
+
+### pluginlake-specific terms
+
+**Three trust boundaries:**
+
+- **Boundary 1 (user → hub):** Who is this researcher, what are they allowed to request? Internal to the hub.
+- **Boundary 2 (hub → station, hub → hub):** Is this node a known, trusted participant in the network with the correct role? First protection layer — rejects unknown orgs and wrong-role requests before any data logic runs. Enforced by Nuts.
+- **Boundary 3 (transaction enforcement at the station):** For this specific request: which datasets, which compute operations, which columns, which row filters, which privacy constraints? Fine-grained enforcement via DSP agreement + ODRL credentials.
+
+| Term | Meaning |
+|---|---|
+| **Nuts VP** | Verifiable Presentation containing `NutsOrganizationCredential`. Used for org-to-org authentication (trust boundary 2). |
+| **PluginlakeAccessCredential** | A Verifiable Credential containing ODRL permissions. Issued by the hub, presented per-request, verified by the station. Proves per-user authorization (trust boundary 3). |
+| **Scoped transfer token** | A short-lived bearer token issued after a transfer completes. Grants access to `GET /dsp/data/{transfer_id}` to pull result data. Not a VC. |
+| **DSP Agreement** | The bilateral contract between hub and station after successful negotiation. Stored in Postgres. Sets outer bounds for all subsequent requests. |
+| **ODRL profile** | pluginlake's constrained subset of ODRL. "Level 2" means: fixed set of actions, constraint types, and asset URN scheme; no arbitrary policy expressions. |
+
+---
+
+## Normative references
+
+- **Health-RI Data Station Specification** (working document, public consultation planned 2026): defines the architecture for data stations and processing hubs for secondary use of health data in the Netherlands. PLUGIN is listed as an implementation. See: https://health-ri.github.io/data-station-specification/en/
+- **Eclipse Dataspace Protocol (DSP) 2025-1**: ISO-track specification defining Catalog Protocol (DCAT + ODRL), Contract Negotiation Protocol, and Transfer Process Protocol. See: https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1/
+- **EHDS Regulation (EU) 2025/327**: entered into force 26 March 2025. Defines data holders, data users, Secure Processing Environments (SPE), and the Health Data Access Body (HDAB). See: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32025R0327
+- **Nuts specification (RFC003, RFC014, RFC022)**: Dutch decentralized identity and authorization for healthcare. See: https://nuts-foundation.gitbook.io/drafts/
+- **TEHDAS2**: technical specifications for Data Access Application Management System (DAAMS) for Health Data Access Bodies. See: https://tehdas.eu/
+
+---
+
+## Context
+
+pluginlake is a federated clinical data platform where data stations (hospitals with OMOP data and compute) and processing hubs (aggregation, statistical integrity, federated learning orchestration) form a network. This architecture implements the data station and processing hub concepts as described in the Health-RI Data Station Specification.
+
+```mermaid
+graph TD
+    R1[Researcher A] --> H1[Processing Hub A<br/>org X or collab]
+    R2[Researcher B] --> H1
+    R3[Researcher C] --> H2[Processing Hub B<br/>org Y]
+    H1 --> S1[Station A<br/>hospital A]
+    H1 --> S2[Station B<br/>hospital B]
+    H2 --> S2
+    H2 --> S3[Station C<br/>hospital C]
+```
+
+Key architectural properties:
+
+- A pluginlake instance is the same software regardless of whether it is a data station or a processing hub. What differs is configuration: which Dagster assets are registered, which DSP role the instance plays (provider vs consumer), which routes are exposed, and which side of a contract the instance is on (issuing credentials vs verifying them). Nuts credentials also differ: both hold a `NutsOrganizationCredential`, but the network role (hub vs station) determines what a node is allowed to do at the Nuts level (e.g. only hub DIDs can initiate data requests to stations). Fine-grained per-user permissions are handled by the PluginlakeAccessCredential (ODRL), not by Nuts.
+- Both hubs and stations have local users (researchers on hubs, data stewards on stations). A researcher belongs to a single hub. Multiple hubs can talk to the same station.
+- A single organization may run both a data station and a processing hub.
+
+### Authentication mechanisms per trust boundary
+
+| Boundary | Auth mechanism | Why |
+|---|---|---|
+| User → Processing Hub (web UI) | PLUGIN OIDC provider (bundled with hub, supports institutional IdP federation and direct login) | Uniform across the network; researchers don't need Nuts awareness |
+| User → Processing Hub (programmatic) | API key with OIDC pre-auth | Flexibility for client/CLI workflows |
+| Processing Hub → Data Station | Nuts vp_token-bearer (org-to-org) | Fully decentralized, inter-organizational |
+| Data Station → Processing Hub (results) | Nuts vp_token-bearer | Same as above, reverse direction |
+
+---
+
+## Decision
+
+Implement DSP 2025-1 HTTPS bindings on the existing FastAPI gateway. The authentication and authorization architecture uses a layered approach where each trust boundary is handled by a dedicated system with no overlapping responsibility.
+
+### Scope for Phase 1
+
+**Provider (data station) only.** pluginlake implements the DSP provider surface: catalog, negotiation acceptance, and transfer execution. The hub-side DSP consumer/client is delivered in Phase 2 alongside per-user credentials.
+
+**Pull transfer only.** After a Dagster job completes, the consumer receives a scoped endpoint URL and token to pull data from DuckLake.
+
+### Adopted approach: Nuts + ODRL (VC-native, no OPA)
+
+Five options were evaluated. The adopted architecture is a VC-native ODRL approach that eliminates OPA entirely:
+
+| Criterion | A: Nuts+OPA | B: OPA only | C: Nuts only | **D: Nuts+ODRL (adopted)** | E: API keys |
+|---|---|---|---|---|---|
+| NL health ecosystem interop | ✓ | ✗ | ✓ | **✓** | ✗ |
+| Per-user audit at station | ✓ | ✓ | ✗ | **Partial** (Phase 1 logs org-level only; Phase 2 adds per-user via VC) | ✗ |
+| Compute constraints | ✓ | ✓ | ✗ | **✗** (not yet implemented: requires formal query/compute approval process) | ✗ |
+| EHDS compliance | ✓ | Partial | Partial (org identity yes, per-user controls missing) | **✓** | ✗ |
+| DSP standards compliance | ✓ | ✓ | ✓ | **✓** | ✗ |
+| Decentralized identity | ✓ | ✗ | ✓ | **✓** | ✗ |
+| Operational complexity | High | Medium | Low | **High** | Low |
+| Custom token format needed | Yes | Yes | No | **No** | No |
+| External dataspace interop | ✓ | ✗ | ✓ | **✓** | ✗ |
+
+### Technology stack
+
+| Layer | Tool | Role |
+|---|---|---|
+| Node identity | Nuts (DID + Verifiable Credentials) | Org-to-org trust |
+| Protocol | DSP 2025-1 (FastAPI, Pydantic) | Catalog, negotiation, transfer |
+| User permissions | PluginlakeAccessCredential (ODRL profile) | Per-user, per-dataset, per-operation |
+| Enforcement | Built-in evaluator module (Python) | Maps ODRL → constrained queries/computations |
+| Privacy | Post-execution validation (processing hub for aggregate operations) | k-anonymity, cardinality limits |
+| VC crypto | PyJWT + cryptography | Sign/verify credentials |
+| Data transfer | DuckLake pull + fastapi (HTTP + scoped token) | Actual data, outside DSP messages |
+
+### Tooling decisions
+
+| Component | Tool | Rationale |
+|---|---|---|
+| ODRL profile evaluation | Custom pluginlake module | No production-grade Python library exists. Constrained profile is small enough to evaluate directly. |
+| VC signature verification | PyJWT + cryptography | Production-grade, well-maintained. |
+| JSON-LD processing | Pydantic (primary) + pyld (optional) | Pydantic handles compacted JSON-LD. `pyld` added later if external connectors send expanded form. |
+| Nuts node client | Auto-generate from OpenAPI spec | Use `openapi-python-client` to generate typed Python client. |
+| DSP protocol implementation | Build: Pydantic models + FastAPI routes | No reusable Python DSP library exists. |
+| Privacy checks | custom pluginlake assets | Simple post-query validation. |
+| Policy storage | Pydantic Settings + YAML | Station-local config. No external policy engine. |
+
+---
+
+## Consequences
+
+- pluginlake gains a DSP-compliant external surface aligned with Health-RI and EHDS
+- Every station runs three sidecars: Nuts node, PostgresQL server and Dagster code server. OPA is not required.
+- The pluginlake ODRL profile (credential schema + actions + constraint types) is the highest priority deliverable
+- Hub signing key distribution must be resolved (DID document, DSP negotiation, or discovery parameters)
+- Station asset registry and operation registry must be defined per station (YAML config)
+- Collaboration hubs need a governance decision on organizational identity before deployment
+- New modules required: `src/pluginlake/authz/` and `src/pluginlake/dsp/`
+- Streamlit UI gets new pages: credential management (central) and access control (datastation)
+
+---
+
+## Design risks by severity
+
+| Risk | Severity | Blocker? |
+|---|---|---|
+| ODRL profile not standardized → stations incompatible | High | Yes, must define before multi-org deployment |
+| Hub signing key distribution mechanism undefined | Medium | Must resolve before implementation |
+| Custom ODRL evaluator correctness (no reference impl) | Medium | Mitigate with comprehensive test suite + DSP Technology Compatibility Kit (TCK) |
+| Collaboration hub credential issuance → governance gap | Medium | Must resolve per collaboration |
+| No existing Bolt (DSP reusable policy template) for research data exchange | Medium | No, ship as default policy file |
+| Sensor reliability for outbound DSP callbacks | Medium | No, mitigatable with retry tracking |
+| Nuts node per station requires outbound network | Medium | Verify per hospital firewall policy |
+| No prior Nuts + DSP + ODRL implementation as reference | Medium | Budget extra integration testing time |
+| Credential re-issuance cost for permission changes | Medium | Mitigate with short-lived VCs + automated issuance |
+
+---
+
+## Open questions
+
+### Must resolve before implementation
+
+1. **Pluginlake ODRL profile specification** — define the exact actions (`pluginlake:aggregate`, `pluginlake:query`, `pluginlake:count`, `pluginlake:compute`), constraint types, and asset URN scheme (`urn:pluginlake:dataset:{name}`).
+2. **PluginlakeAccessCredential schema** — the VC type, required fields, issuer rules, how ODRL permissions are embedded. Candidate for ADR-008.
+3. **Hub signing key distribution** — how stations learn to trust hub signing keys. Likely: hub's DID document contains the signing key.
+4. **Collaboration hub credential issuance** — governance decision per collaboration.
+
+### Deferred to ADR-008: Contract-to-compute mapping and query safety
+
+5. Structured filter AST and query parameterization
+6. Pre-approved algorithm and container registry
+7. Privacy validation for non-aggregate queries
+8. Station-side credential/role synchronization
+9. Collaboration governance and trust boundary separation
+10. Techniques to limit destructive or data-exfiltrating operations
+
+### Can resolve during implementation
+
+11. **OIDC provider selection** — Keycloak (mature, heavy) vs Authentik (lighter, Python-based) as bundled identity provider for boundary 1. Must support upstream IdP federation (SURFconext, Entra ID) and direct login.
+12. ODRL profile extensions (versioned, additive)
+13. Discovery service definition (JSON, ship as default)
+14. Negotiation timeout (operational decision)
+15. Credential validity duration (start with 24-hour VCs)
+16. Processing hub specification alignment (contribute to Health-RI §4.4)
+17. Processing hub DSP client implementation (Phase 2)

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -253,9 +253,10 @@ We use GitHub Actions to automate our CI/CD pipeline. All workflows are defined 
 
 #### CI Workflow (`ci.yaml`)
 
-Runs on every push and pull request to `main`:
-- **Ruff check** linting only (no auto-fixing)
-- **Pytest**: Unit tests on all python code
+Runs on every pull request to `main`:
+- **Ruff check**: linting only (no auto-fixing)
+- **ty check**: static type checking
+- **Pytest**: unit tests with coverage (`--cov=pluginlake`)
 
 #### Security Workflow (`security.yaml`)
 

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -115,6 +115,72 @@ We use [pytest](https://docs.pytest.org/en/stable/) as our testing framework. We
 uv run pytest
 ```
 
+## Branching and Releases
+
+For branch naming and the basic contribution flow, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+### Branch strategy
+
+We use GitHub Flow: one long-lived branch (`main`) with short-lived feature branches.
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Always deployable. Protected, requires PR review. |
+| Feature branches | Short-lived, branched from `main`. Named `<category>/<description>` (e.g., `docs/adrs-changelog`, `feat/cli-module`, `fix/port-mismatch`). |
+
+Releases are tagged commits on `main`, not separate branches.
+
+### Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- **Patch** (`0.1.x`): bug fixes, security bumps, small corrections.
+- **Minor** (`0.x.0`): new features, new modules, non-breaking changes to the package.
+- **Major** (`x.0.0`): breaking changes to public APIs or data formats.
+
+**What does NOT bump the version:**
+
+- Documentation-only changes (deployed continuously via GitHub Pages).
+- CI/CD workflow updates.
+- Test additions or refactors with no code change.
+- ADRs and design specs.
+
+**What bumps the version:**
+
+- Any change to `src/pluginlake/` that affects behavior.
+- Dependency updates that change runtime behavior.
+- Docker image changes that affect deployment.
+
+### Release process
+
+1. Ensure `CHANGELOG.md` is up to date with an `[Unreleased]` section describing all changes since the last release.
+2. Update the version in `pyproject.toml`.
+3. Rename `[Unreleased]` to `[x.y.z] — YYYY-MM-DD` in the changelog (use today's date — the release date is when you tag, not when the code was merged).
+4. Add a fresh empty `[Unreleased]` section above it.
+5. Commit the version bump (can be part of the feature PR that completes the milestone, or a separate small PR).
+6. Merge to `main` via PR.
+7. Tag the merge commit: `git tag vx.y.z && git push --tags`.
+8. Create a GitHub Release from the tag (copies changelog entry as release notes).
+
+### Changelog conventions
+
+We follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Use these categories:
+
+- **Added** for new features or files.
+- **Changed** for changes in existing functionality.
+- **Deprecated** for soon-to-be removed features.
+- **Removed** for removed features or files.
+- **Fixed** for bug fixes.
+- **Security** for vulnerability fixes.
+
+Write entries from the user's perspective. Reference ADRs or PRs where helpful.
+
+**Workflow:**
+
+- Add entries to `[Unreleased]` as you merge PRs (in the PR itself, or right after).
+- When releasing, move entries from `[Unreleased]` into the new version section.
+- The tag should point to the commit that contains the changelog update, so the tagged state is self-documenting.
+
 ## CI/CD
 
 ### Pre-commit hooks

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -197,6 +197,38 @@ We follow the [Linux Foundation policy on generative AI](https://www.linuxfounda
 - GitHub Copilot-specific configuration is in [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md), which references `AGENTS.md`.
 - Other AI tools (Cursor, Claude, etc.) should follow `AGENTS.md` directly.
 
+### Writing good agent instructions
+
+Keep `AGENTS.md` short and precise (under 50 lines). Long instruction files dilute signal because agents lose focus when given too much context at once.
+
+**Principles:**
+
+- State hard rules (what to always/never do), not tutorials.
+- Include project-specific facts an agent cannot infer from code alone (e.g., "use `uv`, not `pip`" or "always read `pyproject.toml` for linting settings").
+- Use hierarchical linking: a top-level file links to domain-specific instruction files that load contextually.
+- Prefer showing one correct example over explaining in prose.
+
+**What to include in the top-level file:**
+
+- What the project is (one sentence).
+- Repository layout (condensed tree).
+- Hard rules (5-10 bullet points max).
+- Links to detailed instruction files.
+
+**What belongs in separate instruction files** (e.g., `.github/instructions/*.md`):
+
+- Language conventions with examples (Python style, type annotations).
+- Framework-specific patterns (Dagster assets, pipeline structure).
+- Deployment and infrastructure context (secrets, known issues).
+
+These files can use `applyTo` patterns so agents only load them when relevant (e.g., Python rules only when editing `*.py`).
+
+**What NOT to put in agent instructions:**
+
+- Anything the agent can infer from `pyproject.toml`, linter config, or existing code.
+- Full API documentation or runbooks. Link to docs instead.
+- Frequently changing information (versions, URLs) that goes stale fast.
+
 ## CI/CD
 
 ### Pre-commit hooks

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -181,6 +181,22 @@ Write entries from the user's perspective. Reference ADRs or PRs where helpful.
 - When releasing, move entries from `[Unreleased]` into the new version section.
 - The tag should point to the commit that contains the changelog update, so the tagged state is self-documenting.
 
+## AI-assisted contributions
+
+We follow the [Linux Foundation policy on generative AI](https://www.linuxfoundation.org/legal/generative-ai): AI-generated code is treated the same as any other contribution.
+
+### Rules
+
+1. **You own your commits.** The contributor is fully responsible for every line they commit, regardless of whether AI assisted in writing it. Review, understand, and validate before committing.
+2. **License compliance.** Ensure the AI tool's terms do not conflict with our Apache-2.0 license. If the output includes identifiable third-party code, verify it is compatibly licensed and provide attribution.
+3. **No special process.** AI-assisted contributions go through the same PR review as any other change.
+
+### Agent configuration
+
+- Agent-agnostic coding instructions live in [`AGENTS.md`](../../AGENTS.md) at the repository root.
+- GitHub Copilot-specific configuration is in [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md), which references `AGENTS.md`.
+- Other AI tools (Cursor, Claude, etc.) should follow `AGENTS.md` directly.
+
 ## CI/CD
 
 ### Pre-commit hooks

--- a/docs/development/develop-guidelines.md
+++ b/docs/development/develop-guidelines.md
@@ -253,23 +253,23 @@ We use GitHub Actions to automate our CI/CD pipeline. All workflows are defined 
 
 #### CI Workflow (`ci.yaml`)
 
-Runs on every push and pull request to `main` and `dev`:
+Runs on every push and pull request to `main`:
 - **Ruff check** linting only (no auto-fixing)
 - **Pytest**: Unit tests on all python code
 
 #### Security Workflow (`security.yaml`)
 
 - Runs **daily at 06:00 UTC** on the default branch
-- Also runs on push to `dev`
+- Can also be triggered manually via workflow dispatch
 - Checks for security vulnerabilities using `uv-secure`
 
-#### Docker Build Workflow (`docker-build.yaml`)
+#### Docker Build Workflow (`docker-build.yaml.disabled`)
 
-Automatically builds and pushes Docker images to Azure Container Registry when relevant files change:
-- Triggers on push to `main` or `dev` when `src/`, `deploy/docker/`, `pyproject.toml`, or `uv.lock` change
-- Uses path filtering to only rebuild affected images
-- Tags: `latest` (main), `dev` (dev branch), and commit SHA
-- Includes SLSA provenance and SBOM attestations
+A disabled scaffold for building and pushing the production images to Azure Container Registry. It is kept with a `.disabled` extension so GitHub does not run it, and needs auth configured (OIDC recommended for a public repo) before being enabled. When enabled it will:
+- Trigger on push to `main` when `src/`, `deploy/docker/`, `pyproject.toml`, or `uv.lock` change
+- Build all images (`pluginlake/pluginlake`, `pluginlake/dagster-webserver`, `pluginlake/ui-central`, `pluginlake/ui-datastation`)
+- Tag: `latest` and commit SHA
+- Include SLSA provenance and SBOM attestations
 
 #### Dependabot
 
@@ -278,4 +278,4 @@ Dependabot is configured to check daily for updates to:
 - GitHub Actions versions
 - Docker base images
 
-All update PRs target the `dev` branch.
+All update PRs target the `main` branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pluginlake"
 version = "0.1.0"
 description = "The federated lakehouse."
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Yannick Vinkesteijn" },
     { name = "Tim Hendriks" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -38,6 +38,8 @@ nav = [
         { "ADR-003: DuckLake + Dagster Integration" = "decisions/adr-003-ducklake-data-catalog.md" },
         { "ADR-004: Data Organization" = "decisions/adr-004-data-organization.md" },
         { "ADR-005: FastAPI Gateway" = "decisions/adr-005-fastapi-gateway.md" },
+        { "ADR-006: Nuts Node" = "decisions/adr-006-nuts-node-decentralized-auth.md" },
+        { "ADR-007: DSP Authorization" = "decisions/adr-007-dataspace-protocol-authz-authc-rbac.md" },
     ]},
     { "Development" = [
         { "Development" = "development/index.md" },


### PR DESCRIPTION
This pull request introduces major improvements to project documentation and contributor onboarding. The most significant updates include the addition of a comprehensive changelog, a clear contributing guide, a session handoff document for collaborative continuity, and substantial restructuring and clarification of architectural decision records (ADRs) and background documentation. These changes enhance transparency, maintainability, and ease of collaboration for both new and existing contributors.

**Documentation and Collaboration Enhancements:**

* Added a detailed `CHANGELOG.md` following the Keep a Changelog format, documenting all notable changes and release history.
* Introduced a `CONTRIBUTING.md` guide covering prerequisites, branching strategy, commit conventions, pull request expectations, and issue reporting to streamline onboarding and contribution quality.
* Created `SESSION_HANDOFF.md` to track the current state of collaborative work, recent accomplishments, next steps, and context for future contributors, improving session continuity.

**Architecture Decision Records and Background Documentation:**

* Added and clarified ADRs:
  * Registered ADR-006 (Nuts Node integration for decentralized identity) and ADR-007 (Dataspace Protocol, authentication, and authorization architecture) in the ADR index and changelog. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R40) [[2]](diffhunk://#diff-e5ec0e7030077b7cf1bfed984f825642d32379d4205ec477e8728dfb71adbefaR12-R13)
  * Rewrote ADR-006 to focus on organizational identity and trust boundaries; clarified terminology, governance, and credential roles.
  * Updated ADR-003 to clarify the rationale for rejecting the "landing zone" alternative, explicitly documenting the decision for direct FastAPI-to-Dagster triggering. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R40) [[2]](diffhunk://#diff-2a5bad80753c0af282fbf60fe16eec89814a3cc38e3236f323687f4e08d0180aL105-R105)
* Restructured documentation navigation and background materials:
  * Added a `docs/background/` section (not in public nav) for in-depth design research, including `dsp-authorization.md` (DSP design spec) and `federated-infrastructure.md` (platform comparison). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R40) [[2]](diffhunk://#diff-1ed8ee1dddc7f3f52e1355cc234b062a50c0897d7d23c870efb7059c4b3d27a5R1-R10)
  * Documented the purpose and contents of the new background section in `docs/background/index.md`.

These updates collectively improve the project's documentation structure, clarify architectural decisions, and facilitate smoother collaboration for all contributors.